### PR TITLE
perf(loaders): import /data/*.json server-side instead of refetching

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,7 +15,8 @@ Living document tracking the multi-stage refactor of `remix-portfolio`. Update t
 3. ✅ **Stage 3 — Storybook** for every component in `app/components/`
 4. ✅ **Stage 4 — Dependency updates** (majors except React; React 18 → 19 deferred)
 5. ✅ **Stage 5 — Code optimization** (perf + a11y + SEO + i18n + CI hygiene)
-6. 🟡 **Stage 6 — Tier-2 follow-ups** (token cleanup, JS code-split (re-attempted), timeline alignment)
+6. ✅ **Stage 6 — Tier-2 follow-ups** (token cleanup, JS code-split (re-attempted), timeline alignment)
+7. 🟡 **Stage 7 — Tier-2 round 2** (server-side `/data/*.json` import to remove a request-time HTTP hop)
 
 Tests come first so every later stage has a safety net. Deps come before optimization so optimization measurements aren't invalidated by a later upgrade.
 
@@ -391,8 +392,8 @@ Still deferred:
 **Goal:** revisit Tier-2 follow-ups from Stage 5 that became viable on a second pass.
 
 **Branch:** `stage-6-tier-2`
-**PR:** _(fill in once opened)_
-**Status:** 🟡 ready for PR
+**PR:** merged
+**Status:** ✅ done
 
 ### What this stage did
 
@@ -409,6 +410,35 @@ Still deferred:
 - `npm run build-storybook` — succeeds.
 - Build warnings: 0 (the previous "dynamic + static import" warnings are gone — the lazy chunks now actually split).
 - Headless chromium smoke test: timeline icon renders dark-bg + green ring + green check, carousel item at 100×100, 29 chart y-axis labels, date center 6.5px from icon center.
+
+---
+
+## Stage 7 — Tier-2 round 2
+
+**Goal:** chase the only "amber" Lighthouse metric (LCP 2.6 s on `/skills`) by removing a request-time HTTP hop.
+
+**Branch:** `stage-7-tier-2-followups`
+**PR:** _(fill in once opened)_
+**Status:** 🟡 ready for PR
+
+### What this stage did
+
+- **Server-side `/data/*.json` import.** All three loaders (`/skills`, `/skills/:uuid`, `/education`) used to do `fetch(new URL('/data/skills.json', request.url))` from inside the Cloudflare Pages Function — a same-region HTTP round-trip on every uncached request. Replaced with direct `import` of the JSON; Vite bakes the data into the server bundle. The static asset is **still served** publicly at `/data/*.json` via the existing `_routes.json` exclude, so no behavior change for any external consumer.
+- **Cleaned up the inferred types.** The literal-inferred type from the JSON is wider than what the loader uses (each optional field becomes a discriminated union), so the loaders cast `as unknown as skillsDataTypes` and `as Certification[]` to match the older runtime expectations. Skill ids in the JSON are numeric (`1`, `2`, …) — `skills._index` was typing them as `string` and the URL builders also expected strings. Tightened: type as `number` in the loader, convert to string at the boundary that serializes to `/skills/:id`.
+- **No Cloudflare config changes.** `_routes.json` already excludes `/data/*` from the Pages Function, and `/data/*` cache-control was set in [public/\_headers](public/_headers) during Stage 5. The asset is now served twice (once embedded in the server bundle, once as a static file at the edge); both copies are <10 KB combined, fine.
+
+### Why the win is real but small
+
+The static asset is served by the Cloudflare edge, not by the Function — but a Function cold-start that needs the data still has to make an outbound HTTP call to its own edge cache. That call is cheap (sub-100 ms in good cases) but it's strictly avoidable. Estimated impact on `/skills` LCP: 50–150 ms saved on cold edge, less when warm. The bigger win is removing two runtime failure modes (`Failed to fetch skills.json` / `Failed to fetch education.json`) and a layer of indirection.
+
+### Verification
+
+- `npm run lint`, `npm run typecheck` — clean.
+- `npm test` — 41/41.
+- `npm run test:e2e --project=chromium` — 15/15.
+- `npm run build-storybook` — succeeds.
+- `npm run build` — clean (only the same pre-existing Remix v3 future-flag warnings).
+- Pending: re-run Lighthouse on the deployed site after merge and save `lighthouse/skills-post-stage-7.json` to compare against the pre-Stage-6 baseline.
 
 ---
 
@@ -431,4 +461,5 @@ Record non-obvious decisions here as they're made (so future-me / future-agent d
 | 3     | `stage-3-storybook`        | merged      | ✅     | yes    |
 | 4     | `stage-4-deps`             | merged      | ✅     | yes    |
 | 5     | `stage-5-optimize`         | merged      | ✅     | yes    |
-| 6     | `stage-6-tier-2`           | _(opening)_ | 🟡     | —      |
+| 6     | `stage-6-tier-2`           | merged      | ✅     | yes    |
+| 7     | `stage-7-tier-2-followups` | _(opening)_ | 🟡     | —      |

--- a/app/routes/education/index.tsx
+++ b/app/routes/education/index.tsx
@@ -1,12 +1,17 @@
 import 'react-vertical-timeline-component/style.min.css';
 
-import { json, type LoaderFunctionArgs, type MetaFunction } from '@remix-run/cloudflare';
+import { json, type MetaFunction } from '@remix-run/cloudflare';
 import { Link, useLoaderData } from '@remix-run/react';
 import { FormattedMessage } from 'react-intl';
 
 import Card, { links as cardLinks } from '~/components/Card';
 import { formatDate, getClassMaker } from '~/utils/utils';
 
+// Import the JSON server-side: Vite bakes it into the server bundle so
+// the loader doesn't have to do an HTTP round-trip to the static asset
+// at /data/education.json on every request. The asset is still served
+// publicly via the `/data/*` exclude in public/_routes.json.
+import educationData from '../../../public/data/education.json';
 import styles from './style.css?url';
 
 export const links = () => [...cardLinks(), { rel: 'stylesheet', href: styles }];
@@ -23,34 +28,25 @@ export const meta: MetaFunction = () => [
 const BLOCK = 'education-route';
 const getClasses = getClassMaker(BLOCK);
 
-type DataTypes = {
-  degree: {
-    title: string;
-    startDate: string;
-    endDate: string;
-    institution: string;
-    description: string;
-  };
-  certifications: {
-    title: string;
-    startDate: string;
-    endDate: string;
-    institution: string;
-    description: string;
-    url?: string;
-  }[];
+type Certification = {
+  title: string;
+  startDate: string;
+  endDate?: string;
+  institution: string;
+  description: string;
+  url?: string;
 };
 
-export async function loader({ request }: LoaderFunctionArgs) {
-  const url = new URL('/data/education.json', request.url);
-
-  const response = await fetch(url.toString());
-  if (!response.ok) {
-    throw new Error('Failed to fetch skills.json');
-  }
-
-  const educationData: DataTypes = await response.json();
-  return json({ degree: educationData.degree, certifications: educationData.certifications });
+export async function loader() {
+  // Widen the inferred type: TS reads the JSON literal and produces a
+  // discriminated union based on which entries have `url`, so
+  // `cert.url` isn't accessible without narrowing. Casting up to a
+  // single shape with `url?: string` matches the old behaviour and
+  // keeps the consumer code simple.
+  return json({
+    degree: educationData.degree,
+    certifications: educationData.certifications as Certification[],
+  });
 }
 
 export default function Skills() {

--- a/app/routes/skills.$uuid/index.tsx
+++ b/app/routes/skills.$uuid/index.tsx
@@ -5,6 +5,9 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import Card, { links as cardLinks } from '~/components/Card';
 import { formatDate, getClassMaker } from '~/utils/utils';
 
+// Server-side import — see app/routes/skills._index/index.tsx for the
+// rationale (Vite bakes the JSON into the server bundle, no HTTP hop).
+import skillsJson from '../../../public/data/skills.json';
 import styles from './style.css?url';
 
 export const links = () => [...cardLinks(), { rel: 'stylesheet', href: styles }];
@@ -62,16 +65,9 @@ const LOGO_DIMS: Record<string, { width: number; height: number }> = {
 };
 const FALLBACK_DIMS = { width: 1000, height: 500 };
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ params }: LoaderFunctionArgs) {
   const id = params && params?.uuid;
-  const url = new URL('/data/skills.json', request.url);
-
-  const response = await fetch(url.toString());
-  if (!response.ok) {
-    throw new Error('Failed to fetch skills.json');
-  }
-
-  const skillsData: skillsDataTypes = await response.json();
+  const skillsData = skillsJson as skillsDataTypes;
   let data;
   let imagePath: string | undefined;
 

--- a/app/routes/skills._index/index.tsx
+++ b/app/routes/skills._index/index.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderFunctionArgs, type MetaFunction } from '@remix-run/cloudflare';
+import { json, type MetaFunction } from '@remix-run/cloudflare';
 import { useLoaderData } from '@remix-run/react';
 import { lazy, Suspense, useCallback, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -13,6 +13,11 @@ import LoadingSpinner, { links as loadingSpinnerLinks } from '~/components/Loadi
 import timelineStyles from '~/components/Timeline/style.css?url';
 import { formatDate, getClassMaker, getSkillChartData } from '~/utils/utils';
 
+// Import the JSON server-side: Vite bakes it into the server bundle so
+// the loader doesn't have to do an HTTP round-trip to the static asset
+// at /data/skills.json on every request. The asset is still served
+// publicly via the `/data/*` exclude in public/_routes.json.
+import skillsData from '../../../public/data/skills.json';
 import styles from './style.css?url';
 
 // Manual CSS preload pattern for code-split components: BarChart,
@@ -68,7 +73,7 @@ type SkillEntryJson = {
 
 type skillsDataTypes = {
   WORK_ITEMS: {
-    id: string;
+    id: number;
     title: string;
     startDate: string;
     endDate?: string | null;
@@ -77,7 +82,7 @@ type skillsDataTypes = {
   }[];
   SKILLS_IMG: {
     title: string;
-    img: string;
+    img?: string;
   }[];
   EXTRA_ACTIVITIES: {
     title: string;
@@ -88,18 +93,17 @@ type skillsDataTypes = {
   }[];
 };
 
-export async function loader({ request }: LoaderFunctionArgs) {
-  const url = new URL('/data/skills.json', request.url);
+export async function loader() {
+  // The JSON's literal-inferred type is wider than we use here (e.g.
+  // optional `end` on skill entries collapses into a union); cast
+  // through `unknown` so TS accepts the narrowing without flagging
+  // a "neither type sufficiently overlaps" error.
+  const typed = skillsData as unknown as skillsDataTypes;
 
-  const response = await fetch(url.toString());
-  if (!response.ok) {
-    throw new Error('Failed to fetch skills.json');
-  }
-
-  const skillsData: skillsDataTypes = await response.json();
-
-  const data = skillsData.WORK_ITEMS.map((item) => ({
-    id: item.id,
+  const data = typed.WORK_ITEMS.map((item) => ({
+    // ids in JSON are numeric, but Timeline + the /skills/:uuid URL
+    // both want strings; convert once here.
+    id: String(item.id),
     title: item.title,
     date: formatDate(item.startDate, item.endDate ?? undefined),
     texts: [item.rol],
@@ -108,17 +112,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
     skills: item.skills.map((s) => s.name),
   }));
 
-  const skills = skillsData.SKILLS_IMG.map((item) => item.title);
+  const skills = typed.SKILLS_IMG.map((item) => item.title);
 
-  const chartData = getSkillChartData(skillsData.WORK_ITEMS);
+  const chartData = getSkillChartData(typed.WORK_ITEMS);
 
   return json(
     {
       data,
-      yearsOfExp: formatDate(skillsData.WORK_ITEMS[0].startDate, undefined, 'fullYearMonth'),
+      yearsOfExp: formatDate(typed.WORK_ITEMS[0].startDate, undefined, 'fullYearMonth'),
       skills,
       chartData,
-      extraActivities: skillsData.EXTRA_ACTIVITIES,
+      extraActivities: typed.EXTRA_ACTIVITIES,
     },
     {
       headers: {

--- a/lighthouse/README.md
+++ b/lighthouse/README.md
@@ -51,14 +51,14 @@ npx lighthouse https://gonzalo-alvarez-campos-cv.com/skills \
 
 Diff the metric block between runs. The fields that matter:
 
-| Field path | What it means | Threshold |
-| --- | --- | --- |
-| `audits["first-contentful-paint"].numericValue` | FCP (ms) | <1800 = good |
-| `audits["largest-contentful-paint"].numericValue` | LCP (ms) | <2500 = good |
-| `audits["speed-index"].numericValue` | Speed Index (ms) | <3387 = good |
-| `audits["total-blocking-time"].numericValue` | TBT (ms) | <200 = good |
-| `audits["cumulative-layout-shift"].numericValue` | CLS (unitless) | <0.1 = good |
-| `categories.performance.score` | Overall perf score, 0–1 | ≥0.9 = green |
+| Field path                                        | What it means           | Threshold    |
+| ------------------------------------------------- | ----------------------- | ------------ |
+| `audits["first-contentful-paint"].numericValue`   | FCP (ms)                | <1800 = good |
+| `audits["largest-contentful-paint"].numericValue` | LCP (ms)                | <2500 = good |
+| `audits["speed-index"].numericValue`              | Speed Index (ms)        | <3387 = good |
+| `audits["total-blocking-time"].numericValue`      | TBT (ms)                | <200 = good  |
+| `audits["cumulative-layout-shift"].numericValue`  | CLS (unitless)          | <0.1 = good  |
+| `categories.performance.score`                    | Overall perf score, 0–1 | ≥0.9 = green |
 
 Quick diff with `jq`:
 
@@ -79,8 +79,8 @@ Captured manually before saving the full JSON; numbers are from the
 metrics block of the report. If a row says "—" the JSON file isn't
 saved yet.
 
-| File | Route | Stage at run time | FCP | LCP | SI | Perf score |
-| --- | --- | --- | --- | --- | --- | --- |
+| File                      | Route     | Stage at run time             | FCP   | LCP   | SI    | Perf score        |
+| ------------------------- | --------- | ----------------------------- | ----- | ----- | ----- | ----------------- |
 | `skills-pre-stage-6.json` | `/skills` | After Stage 5, before Stage 6 | 1.6 s | 2.6 s | 1.9 s | (paste from JSON) |
 
 Notes:


### PR DESCRIPTION
The three loaders (/skills, /skills/:uuid, /education) used to call fetch(new URL('/data/<file>.json', request.url)) from inside the Cloudflare Pages Function — a same-region HTTP round-trip on every uncached request, plus a JSON parse, plus a failure mode ("Failed to fetch skills.json") that nothing recovered from.

Replaced with a direct `import` of the JSON. Vite bakes the data into the server bundle; no runtime HTTP. The static asset is still served publicly at /data/<file>.json via the existing `/data/*` exclude in public/_routes.json, so any external consumer keeps working.

Type cleanup that came with the refactor:
- Skill ids in the JSON are numeric (1, 2, …) — skills._index was typing them as `string` and the URL builder also expected strings. Tighter: type as `number` in the loader, convert to string at the boundary that serializes to /skills/:id.
- The literal-inferred type from Vite's JSON import is wider than what the loaders use (each optional field becomes a discriminated union). Narrowed via `as unknown as skillsDataTypes` / `as Certification[]` casts so consumer code stays the same.

Estimated impact on /skills LCP (the only "amber" Lighthouse metric in the pre-Stage-7 baseline): 50–150 ms saved on cold edge, less when warm. Bigger wins are the simpler control flow and removing the fetch-failure modes.

No Cloudflare config changes needed — `/data/*` was already excluded from the Pages Function and edge-cached via _headers in Stage 5.

Verification:
- npm run lint / typecheck — clean
- npm test — 41/41
- npm run test:e2e --project=chromium — 15/15
- npm run build-storybook — succeeds
- npm run build — clean (only the pre-existing Remix v3 future-flag warnings)