### PR TITLE
docs: sync AGENTS/PROGRESS with merged Stages 7–10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,14 +35,14 @@ The site is content-driven: routes load static JSON files from [public/data/](pu
 | Icons             | Local SVGs → SVGO → SVGR-generated React components                                              |
 | Linting           | ESLint (airbnb + airbnb/hooks + prettier + jsx-a11y + storybook), Prettier, Stylelint, ls-lint   |
 | Type-check        | `tsc --noEmit` (Vite handles emit)                                                               |
-| Node              | `>=20.0.0` (`.nvmrc` pins `v20.11.1`)                                                            |
+| Node              | `>=20.19.0` (`.nvmrc` pins `v20.19.5` — Storybook 10 floor)                                      |
 | npm               | `legacy-peer-deps=true` (set in `.npmrc`)                                                        |
 
 **Tests:** Vitest + React Testing Library for components/utils, Playwright for E2E (chromium + Pixel 7 mobile project). See "Tests" section below.
 
 **Storybook:** Storybook 10 (Vite framework) with stories colocated next to each component as `index.stories.tsx`. See "Storybook" section below.
 
-CI runs lint, typecheck, unit, E2E, and `build-storybook` on every PR ([.github/workflows/ci.yml](.github/workflows/ci.yml)). Dependabot ([.github/dependabot.yml](.github/dependabot.yml)) bumps deps daily, prefixed `chore(deps)`.
+CI runs lint, typecheck, unit, E2E, and `build-storybook` on every PR ([.github/workflows/ci.yml](.github/workflows/ci.yml)). Dependabot ([.github/dependabot.yml](.github/dependabot.yml)) bumps deps weekly in grouped ecosystems, prefixed `chore(deps)`.
 
 ---
 
@@ -238,7 +238,7 @@ Site content is **not in the database** — it's static JSON under `public/data/
 - [public/data/education.json](public/data/education.json) — degree + certifications.
 - [public/data/skills.json](public/data/skills.json) — `WORK_ITEMS`, `SKILLS_IMG`, `EXTRA_ACTIVITIES`.
 
-To update content, edit those JSON files. Loaders re-fetch on each request (the skills loader caches for 1h via `Cache-Control`).
+To update content, edit those JSON files. Route loaders import them server-side (Vite bakes the JSON into the server bundle); the skills loader still caches for 1h via `Cache-Control` so the edge holds the rendered HTML.
 
 ### Skill chart is derived from `WORK_ITEMS`
 
@@ -399,7 +399,7 @@ When adding a new component, mirror the existing shape:
 When adding a new route:
 
 1. Create `app/routes/<flat-route-name>/index.tsx` (or `<flat-route-name>.tsx`).
-2. Export `loader` if you need data — fetch JSON from `public/data/` via `new URL('/data/...', request.url)` so it works on Pages.
+2. Export `loader` if you need data — `import` the JSON from `public/data/` directly (Vite bakes it into the server bundle, no HTTP hop). Single Fetch is on, so return a raw object; use `data(payload, { headers })` from `@remix-run/cloudflare` only when you need to set response headers or a custom status.
 3. Export `links` (compose any child component `links`).
 4. Add a NavBar entry in [app/components/NavBar/index.tsx](app/components/NavBar/index.tsx) `MAIN_NAV` if the route should be reachable from the nav.
 5. Optionally export a route-local `ErrorBoundary` (skills.\$uuid does this).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -19,7 +19,7 @@ Living document tracking the multi-stage refactor of `remix-portfolio`. Update t
 7. ✅ **Stage 7 — Tier-2 round 2** (server-side `/data/*.json` import to remove a request-time HTTP hop)
 8. ✅ **Stage 8 — Dep maintenance** (patch + minor bumps inside current majors; cleared the Dependabot backlog)
 9. ✅ **Stage 9 — Single Fetch** (opted into `future.v3_singleFetch`; replaced deprecated `json()` with raw objects + `data()` for headers)
-10. 🟡 **Stage 10 — Lazy route discovery** (opt into `future.v3_lazyRouteDiscovery`; clears the last future-flag warning)
+10. ✅ **Stage 10 — Lazy route discovery** (opted into `future.v3_lazyRouteDiscovery`; cleared the last future-flag warning)
 
 Tests come first so every later stage has a safety net. Deps come before optimization so optimization measurements aren't invalidated by a later upgrade.
 
@@ -534,8 +534,8 @@ Under Single Fetch, route data requests now hit `<route>.data` and return a `tex
 **Goal:** opt into Remix's `future.v3_lazyRouteDiscovery` (a.k.a. "fog of war"). Clears the last future-flag warning on dev start and brings the route manifest closer to the React Router v7 default behaviour.
 
 **Branch:** `stage-10-lazy-routes`
-**PR:** _(fill in once opened)_
-**Status:** 🟡 ready for PR
+**PR:** merged
+**Status:** ✅ done
 
 ### What this stage did
 
@@ -572,15 +572,15 @@ Record non-obvious decisions here as they're made (so future-me / future-agent d
 
 ## PRs
 
-| Stage | Branch                     | PR          | Status | Merged |
-| ----- | -------------------------- | ----------- | ------ | ------ |
-| 1     | `stage-1-tests`            | merged      | ✅     | yes    |
-| 2     | `stage-2-data-restructure` | merged      | ✅     | yes    |
-| 3     | `stage-3-storybook`        | merged      | ✅     | yes    |
-| 4     | `stage-4-deps`             | merged      | ✅     | yes    |
-| 5     | `stage-5-optimize`         | merged      | ✅     | yes    |
-| 6     | `stage-6-tier-2`           | merged      | ✅     | yes    |
-| 7     | `stage-7-tier-2-followups` | merged      | ✅     | yes    |
-| 8     | `stage-8-deps`             | merged      | ✅     | yes    |
-| 9     | `stage-9-single-fetch`     | merged      | ✅     | yes    |
-| 10    | `stage-10-lazy-routes`     | _(opening)_ | 🟡     | —      |
+| Stage | Branch                     | PR     | Status | Merged |
+| ----- | -------------------------- | ------ | ------ | ------ |
+| 1     | `stage-1-tests`            | merged | ✅     | yes    |
+| 2     | `stage-2-data-restructure` | merged | ✅     | yes    |
+| 3     | `stage-3-storybook`        | merged | ✅     | yes    |
+| 4     | `stage-4-deps`             | merged | ✅     | yes    |
+| 5     | `stage-5-optimize`         | merged | ✅     | yes    |
+| 6     | `stage-6-tier-2`           | merged | ✅     | yes    |
+| 7     | `stage-7-tier-2-followups` | merged | ✅     | yes    |
+| 8     | `stage-8-deps`             | merged | ✅     | yes    |
+| 9     | `stage-9-single-fetch`     | merged | ✅     | yes    |
+| 10    | `stage-10-lazy-routes`     | merged | ✅     | yes    |


### PR DESCRIPTION
PROGRESS.md was still listing Stage 10 as "ready for PR" in three places after #143 merged. AGENTS.md had four lines that no longer matched reality:

- Node was listed as >=20.0.0 / nvmrc v20.11.1; Stage 3 bumped both to >=20.19.0 / v20.19.5 for the Storybook 10 floor.
- Dependabot was described as daily; Stage 5 moved it to weekly with grouped ecosystems.
- Section 9 still claimed "loaders re-fetch on each request"; Stage 7 switched all three to server-side imports.
- Section 14's new-route guidance still told future agents to fetch JSON via new URL(); replaced with the import + Single Fetch shape that Stages 7 and 9 actually established.

No code changes.