### PR TITLE
docs: capture post-Stage-13 lighthouse + sync AGENTS CSS conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,21 +165,50 @@ Each component owns its `style.css` next to its `index.tsx`, written in BEM:
 .block-name--modifier { ... }
 ```
 
-CSS is wired in via Remix's `links()` export, which is the convention every component follows:
+There are **two patterns** for getting that CSS to the browser. Pick the right one for the component you're adding.
+
+#### Pattern A — postcss-import inline (default for small / always-needed components)
+
+Stage 13 collapsed most per-component stylesheets into the consuming route's stylesheet (or the global stylesheet, for components used everywhere). The mechanism is `postcss-import`, which is already wired up in [postcss.config.js](postcss.config.js): the build expands `@import` directives at compile time, so one stylesheet ships instead of many.
+
+The component itself just owns its `style.css`. **No `links()` export, no `?url` import.** The consumer adds an `@import` at the top of its own `style.css`:
+
+```css
+/* app/routes/skills._index/style.css */
+@import '../../components/Card/style.css';
+@import '../../components/Input/style.css';
+
+.skills-route {
+  /* ... */
+}
+```
+
+Components currently inlined this way: `Button`, `Card`, `DownloadBtn`, `Input`, `LoadingSpinner`, `NavBar`. Buttons + NavBar are inlined into [app/styles/style.css](app/styles/style.css) since they're on every page; the rest are inlined into the routes that consume them.
+
+#### Pattern B — Remix `links()` (lazy-loaded heavy components only)
+
+`BarChart`, `Carousel`, and `Timeline` are JS-lazy-loaded on `/skills` via `lazy()` + `Suspense`. Their CSS still needs to land on first paint (otherwise the component flashes unstyled when its chunk arrives), so they keep the manual-CSS-preload pattern from Stage 6:
 
 ```ts
+// app/components/Timeline/index.tsx
 import styles from './style.css?url';
-export const links = () => [{ rel: 'stylesheet', href: styles }];
+
+export const links = () => [
+  { rel: 'preload', href: styles, as: 'style' },
+  { rel: 'stylesheet', href: styles },
+];
 ```
 
-Parent components/routes compose children's `links()`:
+The consuming route then either composes the component's `links()` chain or — if statically importing the component would defeat its lazy-chunk split — pipes the CSS in as a `?url` string directly in the route's `links()`. See [app/routes/skills.\_index/index.tsx](app/routes/skills._index/index.tsx) for the latter.
 
-```ts
-import Card, { links as cardLinks } from '~/components/Card';
-export const links = () => [...cardLinks(), { rel: 'stylesheet', href: styles }];
-```
+#### Which pattern do I use?
 
-This is critical: **if a component is added that has its own CSS, the consumer must spread its `links()` or the styles won't load**. The chain bottoms out at `app/root.tsx`'s `links()`.
+- **Pattern A (postcss-import inline)** — small CSS files (≤ a few KB), components used everywhere or on a known set of routes, no JS code-split.
+- **Pattern B (links())** — heavy components (vendor CSS like `react-vertical-timeline-component/style.min.css`, big chunks of recharts styling) that are _also_ JS-lazy-loaded. The trade you're making: an extra round-trip for a stylesheet, in exchange for keeping the component's JS off the eager bundle.
+
+Whichever pattern you pick: **don't mix them on the same component.** Both an `@import` and a `links()` entry would emit the CSS twice.
+
+The chain bottoms out at [app/root.tsx](app/root.tsx)'s `links()`, which always loads `app/styles/style.css` (containing global styles + the `@import`-inlined NavBar/Button CSS) and `app/styles/tailwind.css`.
 
 ### `getClassMaker` (BEM helper)
 
@@ -390,7 +419,7 @@ When adding a new component, mirror the existing shape:
 
 1. Folder under `app/components/<PascalCase>/` containing `index.tsx` (+ `style.css` if it has styles).
 2. `const BLOCK = 'kebab-case-block'; const getClasses = getClassMaker(BLOCK);`
-3. Default-export the component; named-export `links` if the component has CSS (or composes a child's).
+3. Default-export the component. **No `links()` export by default** — the consuming route's stylesheet inlines the CSS via `@import` (Pattern A in §6). Only export `links()` if the component is JS-lazy-loaded and needs the manual-CSS-preload pattern (Pattern B). When in doubt, default to Pattern A.
 4. Type props inline (`type FooProps = { ... }`) and give optional props defaults in the parameter destructure (so `react/require-default-props` is satisfied).
 5. Use `~/components/icons` for any iconography rather than inlining SVG.
 6. For links, prefer `<Link to=...>` from `@remix-run/react`; use [ConditionalLink](app/components/ConditionalWrapper/index.tsx#L32) when an element should only become a link under some condition.
@@ -400,7 +429,7 @@ When adding a new route:
 
 1. Create `app/routes/<flat-route-name>/index.tsx` (or `<flat-route-name>.tsx`).
 2. Export `loader` if you need data — `import` the JSON from `public/data/` directly (Vite bakes it into the server bundle, no HTTP hop). Single Fetch is on, so return a raw object; use `data(payload, { headers })` from `@remix-run/cloudflare` only when you need to set response headers or a custom status.
-3. Export `links` (compose any child component `links`).
+3. Add a `style.css` next to the route if it has styles, and `@import` any small components it consumes at the top of that file (see §6 Pattern A). Export `links` listing the route's own stylesheet plus any Pattern B (lazy-loaded) component stylesheets.
 4. Add a NavBar entry in [app/components/NavBar/index.tsx](app/components/NavBar/index.tsx) `MAIN_NAV` if the route should be reachable from the nav.
 5. Optionally export a route-local `ErrorBoundary` (skills.\$uuid does this).
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -22,7 +22,8 @@ Living document tracking the multi-stage refactor of `remix-portfolio`. Update t
 10. ✅ **Stage 10 — Lazy route discovery** (opted into `future.v3_lazyRouteDiscovery`; cleared the last future-flag warning)
 11. ✅ **Stage 11 — Doc sync** (caught AGENTS.md and PROGRESS.md up to what the code actually does after Stages 7–10 merged; no code changes)
 12. ✅ **Stage 12 — A11y / SEO quick wins** (per-route canonical + SVGR aria-hidden default, fixed two regressions from the post-Stage-10 Lighthouse run)
-13. 🟡 **Stage 13 — LCP recovery** (collapsed 12 render-blocking stylesheets on `/skills` to 7 by inlining small-component CSS into route stylesheets via postcss-import; dropped 5 components' `links()` exports)
+13. ✅ **Stage 13 — LCP recovery** (collapsed 12 render-blocking stylesheets on `/skills` to 7 by inlining small-component CSS into route stylesheets via postcss-import; dropped 5 components' `links()` exports)
+14. 🟡 **Stage 14 — Doc sync + post-Stage-13 Lighthouse capture** (record the actual Stage 12+13 perf delta; bring AGENTS.md §6/§14 in line with the new CSS conventions)
 
 Tests come first so every later stage has a safety net. Deps come before optimization so optimization measurements aren't invalidated by a later upgrade.
 
@@ -606,8 +607,8 @@ Need a fresh prod run after this merges to confirm, but the predictable scores:
 **Goal:** chase the LCP regression that surfaced in the post-Stage-10 prod Lighthouse run (2.2 s → 2.6 s, score 0.94 → 0.87). Reduce the number of render-blocking stylesheets without losing the JS code-split that landed in Stage 6.
 
 **Branch:** `stage-13-lcp-recovery`
-**PR:** _(fill in once opened)_
-**Status:** 🟡 ready for PR
+**PR:** merged
+**Status:** ✅ done
 
 ### Diagnosis
 
@@ -663,6 +664,44 @@ If Lantern still penalizes the route heavily, the Tier-2 follow-up would be inli
 
 ---
 
+## Stage 14 — Doc sync + post-Stage-13 Lighthouse capture
+
+**Goal:** close out Stages 12 and 13 by recording the actual prod Lighthouse delta and bringing AGENTS.md in line with the new CSS conventions. No code changes.
+
+**Branch:** `stage-14-doc-sync-and-lighthouse`
+**PR:** _(fill in once opened)_
+**Status:** 🟡 ready for PR
+
+### What this stage did
+
+- **Captured the post-Stage-13 prod Lighthouse run** as [lighthouse/skills-post-stage-13.summary.json](lighthouse/skills-post-stage-13.summary.json) and added a row + score breakdown to [lighthouse/RESULTS.md](lighthouse/RESULTS.md). Both Stage 12 and Stage 13 predictions are confirmed:
+
+  | Metric                | Post-Stage-10 | Post-Stage-13    | Δ                      |
+  | --------------------- | ------------- | ---------------- | ---------------------- |
+  | Performance           | 0.97          | **0.98**         | +0.01                  |
+  | Accessibility         | 0.99          | **1.00**         | +0.01 (Stage 12)       |
+  | Best Practices        | 1.00          | 1.00             | —                      |
+  | SEO                   | 0.92          | **1.00**         | +0.08 (Stage 12)       |
+  | LCP                   | 2.6 s (0.87)  | **2.2 s (0.94)** | **−437 ms** (Stage 13) |
+  | `/skills` stylesheets | 12            | **7**            | **−5** (Stage 13)      |
+
+- The `svg-img-alt` audit is now `notApplicable` (no SVGs carry `role="img"` after Stage 12). The `canonical` audit passes. Network dependency tree's longest critical chain dropped from 387 ms (12 stylesheets) to 322 ms (7).
+
+- **AGENTS.md §6 (Styling system).** Documented the two CSS patterns the codebase actually uses now:
+  - **Pattern A — `postcss-import` inline.** Default for small, always-needed components. Component owns its `style.css` only; the consuming route adds an `@import` at the top of its own stylesheet. No `links()`, no `?url`. Currently used by Button, Card, DownloadBtn, Input, LoadingSpinner, NavBar.
+  - **Pattern B — Remix `links()`.** Reserved for JS-lazy-loaded heavies (BarChart, Carousel, Timeline) that still need their CSS on first paint. Manual `?url` preload + stylesheet pair. The trade is one stylesheet round-trip in exchange for keeping the JS off the eager bundle.
+
+- **AGENTS.md §14 (Component patterns).** Updated the "new component" checklist to default to no `links()` export (Pattern A) and the "new route" checklist to call out `@import`-ing consumed components in the route's stylesheet.
+
+- **Dropped the critical-CSS-inline followup.** Post-Stage-10 we'd flagged it as a Tier-2 lever if Lantern still penalized `/skills` after Stage 13. With LCP recovered to 0.94 and Performance at 0.98, it's not justified by the score. RESULTS.md notes this explicitly.
+
+### Verification
+
+- `npm run lint` clean (Prettier-checked the docs).
+- No code changes, so existing test/build pipeline is untouched.
+
+---
+
 ## Decisions log
 
 Record non-obvious decisions here as they're made (so future-me / future-agent doesn't have to re-derive them):
@@ -675,18 +714,19 @@ Record non-obvious decisions here as they're made (so future-me / future-agent d
 
 ## PRs
 
-| Stage | Branch                        | PR          | Status | Merged |
-| ----- | ----------------------------- | ----------- | ------ | ------ |
-| 1     | `stage-1-tests`               | merged      | ✅     | yes    |
-| 2     | `stage-2-data-restructure`    | merged      | ✅     | yes    |
-| 3     | `stage-3-storybook`           | merged      | ✅     | yes    |
-| 4     | `stage-4-deps`                | merged      | ✅     | yes    |
-| 5     | `stage-5-optimize`            | merged      | ✅     | yes    |
-| 6     | `stage-6-tier-2`              | merged      | ✅     | yes    |
-| 7     | `stage-7-tier-2-followups`    | merged      | ✅     | yes    |
-| 8     | `stage-8-deps`                | merged      | ✅     | yes    |
-| 9     | `stage-9-single-fetch`        | merged      | ✅     | yes    |
-| 10    | `stage-10-lazy-routes`        | merged      | ✅     | yes    |
-| 11    | `stage-11-doc-sync`           | merged      | ✅     | yes    |
-| 12    | `stage-12-a11y-seo-quickwins` | merged      | ✅     | yes    |
-| 13    | `stage-13-lcp-recovery`       | _(opening)_ | 🟡     | —      |
+| Stage | Branch                             | PR          | Status | Merged |
+| ----- | ---------------------------------- | ----------- | ------ | ------ |
+| 1     | `stage-1-tests`                    | merged      | ✅     | yes    |
+| 2     | `stage-2-data-restructure`         | merged      | ✅     | yes    |
+| 3     | `stage-3-storybook`                | merged      | ✅     | yes    |
+| 4     | `stage-4-deps`                     | merged      | ✅     | yes    |
+| 5     | `stage-5-optimize`                 | merged      | ✅     | yes    |
+| 6     | `stage-6-tier-2`                   | merged      | ✅     | yes    |
+| 7     | `stage-7-tier-2-followups`         | merged      | ✅     | yes    |
+| 8     | `stage-8-deps`                     | merged      | ✅     | yes    |
+| 9     | `stage-9-single-fetch`             | merged      | ✅     | yes    |
+| 10    | `stage-10-lazy-routes`             | merged      | ✅     | yes    |
+| 11    | `stage-11-doc-sync`                | merged      | ✅     | yes    |
+| 12    | `stage-12-a11y-seo-quickwins`      | merged      | ✅     | yes    |
+| 13    | `stage-13-lcp-recovery`            | merged      | ✅     | yes    |
+| 14    | `stage-14-doc-sync-and-lighthouse` | _(opening)_ | 🟡     | —      |

--- a/lighthouse/RESULTS.md
+++ b/lighthouse/RESULTS.md
@@ -12,22 +12,26 @@ summary using the convention in [README.md](README.md).
 
 ## /skills timeline
 
-| Run                          | FCP         | LCP         | SI      | benchmarkIndex  |
-| ---------------------------- | ----------- | ----------- | ------- | --------------- |
-| pre-Stage-6 (after Stage 5)  | 1.6 s       | 2.6 s       | 1.9 s   | 3175.5          |
-| post-Stage-7 (after Stage 7) | 1.2 s       | 2.2 s       | 2.4 s   | 3180            |
-| **Δ**                        | **−437 ms** | **−437 ms** | +482 ms | ~0 (env stable) |
+| Run                            | FCP    | LCP         | SI      | TBT   | Stylesheets | benchmarkIndex      |
+| ------------------------------ | ------ | ----------- | ------- | ----- | ----------- | ------------------- |
+| pre-Stage-6 (after Stage 5)    | 1.6 s  | 2.6 s       | 1.9 s   | —     | —           | 3175.5              |
+| post-Stage-7 (after Stage 7)   | 1.2 s  | 2.2 s       | 2.4 s   | —     | —           | 3180                |
+| post-Stage-10 (after Stage 10) | 1.1 s  | 2.6 s       | 1.8 s   | 15 ms | 12          | 3175                |
+| post-Stage-13 (after Stage 13) | 1.2 s  | 2.2 s       | 2.0 s   | 8 ms  | **7**       | 3214                |
+| **Stage 11→13 Δ**              | +27 ms | **−437 ms** | +186 ms | −7 ms | **−5**      | run-to-run variance |
 
 Lighthouse score breakdown:
 
-| Run          | FCP score | LCP score | SI score |
-| ------------ | --------- | --------- | -------- |
-| pre-Stage-6  | 0.94      | 0.86      | 1.00     |
-| post-Stage-7 | 0.99      | 0.94      | 0.98     |
+| Run           | FCP score | LCP score | SI score | Perf | A11y | BP   | SEO  |
+| ------------- | --------- | --------- | -------- | ---- | ---- | ---- | ---- |
+| pre-Stage-6   | 0.94      | 0.86      | 1.00     | —    | —    | —    | —    |
+| post-Stage-7  | 0.99      | 0.94      | 0.98     | —    | —    | —    | —    |
+| post-Stage-10 | 0.99      | 0.87      | 1.00     | 0.97 | 0.99 | 1.00 | 0.92 |
+| post-Stage-13 | 0.99      | **0.94**  | 0.99     | 0.98 | 1.00 | 1.00 | 1.00 |
 
 ## What moved the numbers
 
-**Stage 6** (merged between the two runs):
+**Stage 6** (merged between the pre-Stage-6 and post-Stage-7 runs):
 
 - Code-split BarChart, Carousel, and Timeline on `/skills` via the
   manual CSS-preload pattern. Recharts (~333 KB JS) and the 25
@@ -35,13 +39,30 @@ Lighthouse score breakdown:
 - Removed 7 unused design tokens.
 - Polished timeline icon/date alignment.
 
-**Stage 7** (also between the two runs):
+**Stage 7** (also between those runs):
 
 - Replaced the loaders' `fetch(new URL('/data/*.json', request.url))`
   with a direct server-side `import`. Removed one HTTP round-trip
   from every uncached `/skills` and `/skills/:uuid` request.
 
+**Stage 12** (between post-Stage-10 and post-Stage-13):
+
+- Per-route canonical from the root loader (was hardcoded to `SITE_URL`).
+- SVGR-generated icons now ship `aria-hidden="true"` instead of
+  `role="img"` — they're decorative; their parents carry the name.
+
+**Stage 13** (between post-Stage-10 and post-Stage-13):
+
+- Inlined small-component CSS (Button, NavBar, Card, Input,
+  LoadingSpinner, DownloadBtn) into the consuming routes' / global
+  stylesheet via `postcss-import`. `/skills` went from 12 separate
+  render-blocking stylesheets to 7. Lazy-loaded heavies (BarChart,
+  Carousel, Timeline) keep their independent stylesheets to preserve
+  Stage 6's JS chunk-split.
+
 ## Reading the deltas
+
+### Stage 5 → Stage 7 era
 
 - **LCP −437 ms.** This is the metric Google actually penalizes, and
   it crossed the 2.5 s "good" threshold from the wrong side. Score
@@ -57,6 +78,33 @@ Lighthouse score breakdown:
   shifts later even though first content arrives sooner. SI 2.4 s is
   still firmly in Lighthouse's "good" band (threshold 3.4 s); the
   score moved 1.00 → 0.98. Worth it for the LCP win.
+
+### Stage 10 → Stage 13 era
+
+- **LCP −437 ms (again).** The post-Stage-10 baseline showed LCP had
+  drifted back to 2.6 s — not a real-user regression (observed LCP
+  was 439 ms; FCP and SI both improved over post-Stage-7), but
+  Lighthouse's Lantern simulator charges per-stylesheet round-trip
+  cost under 4× CPU + slow-3G, and Stage 6's manual-CSS-preload
+  pattern was emitting **12 separate render-blocking stylesheets**
+  on `/skills`. Stage 13 collapsed that to 7 via `postcss-import`,
+  and LCP recovered to 2.2 s with score 0.87 → 0.94.
+- **A11y 0.99 → 1.00.** Stage 12's SVGR `aria-hidden` default
+  removed all 30 `svg-img-alt` failures; the audit is now
+  `notApplicable` because no SVGs carry `role="img"` anymore.
+- **SEO 0.92 → 1.00.** Stage 12's per-route canonical fixed the
+  only failing audit (`canonical` had been pinned to the homepage
+  via `links()`).
+- **TBT −7 ms** and **TTFB −85 ms** are run-to-run variance from the
+  Cloudflare edge / Lantern, not stage work.
+
+## Critical-CSS-inline followup: not pursued
+
+Post-Stage-10 we noted critical-CSS inline as a Tier-2 lever if
+Lantern still penalized `/skills` after Stage 13. With LCP back at
+0.94 and Performance at 0.98, that work isn't justified by the
+score. If a future stage moves the LCP element to something heavier
+than the `<h2>Work Experience</h2>` text, revisit.
 
 ## Next thing to measure
 

--- a/lighthouse/skills-post-stage-13.summary.json
+++ b/lighthouse/skills-post-stage-13.summary.json
@@ -1,0 +1,42 @@
+{
+  "fetchTime": "2026-06-18T12:04:10.636Z",
+  "requestedUrl": "https://gonzalo-alvarez-campos-cv.com/skills",
+  "lighthouseVersion": "13.2.0",
+  "categories": {
+    "performance": 0.98,
+    "accessibility": 1.0,
+    "best-practices": 1.0,
+    "seo": 1.0
+  },
+  "metrics": {
+    "fcp": { "displayValue": "1.2 s", "numericValue": 1160.1, "score": 0.99 },
+    "lcp": { "displayValue": "2.2 s", "numericValue": 2210.1, "score": 0.94 },
+    "si": { "displayValue": "2.0 s", "numericValue": 1986.44, "score": 0.99 },
+    "tbt": { "displayValue": "10 ms", "numericValue": 8, "score": 1.0 },
+    "cls": { "displayValue": "0.001", "numericValue": 0.0012, "score": 1.0 },
+    "tti": { "displayValue": "4.0 s", "numericValue": 4039.6 },
+    "ttfb": 169
+  },
+  "failingAudits": [],
+  "deltas": {
+    "vsPostStage10": {
+      "performance": "+0.01 (0.97 -> 0.98)",
+      "accessibility": "+0.01 (0.99 -> 1.00; svg-img-alt fixed in Stage 12)",
+      "seo": "+0.08 (0.92 -> 1.00; canonical fixed in Stage 12)",
+      "lcp": "-437ms (2.6s -> 2.2s; back into Lighthouse 'good' band, 0.87 -> 0.94)",
+      "fcp": "+27ms (1.1s -> 1.2s; within run-to-run variance)",
+      "si": "+186ms (1.8s -> 2.0s; within run-to-run variance, score 1.0 -> 0.99)",
+      "tbt": "-7ms (15ms -> 8ms)",
+      "ttfb": "-85ms (254ms -> 169ms; Cloudflare edge variance)",
+      "stylesheetCount": "/skills: 12 -> 7 render-blocking stylesheets",
+      "totalRequests": "33 -> 28"
+    }
+  },
+  "notes": [
+    "Both Stage 12 predictions confirmed: SEO 0.92 -> 1.00 (canonical), A11y 0.99 -> 1.00 (svg-img-alt now notApplicable since no SVGs carry role=\"img\" anymore).",
+    "Stage 13 LCP recovery confirmed: 2.6s -> 2.2s (-437ms), score 0.87 -> 0.94. The Tier-2 critical-CSS-inline followup is no longer warranted.",
+    "Network dependency tree shows the longest critical chain dropped from 387ms (12 stylesheets) to 322ms (7 stylesheets).",
+    "Render-blocking insight is now scored 0.5 with 7 entries (vs 12 prior). Further reduction would require giving up Stage 6's per-route CSS-split granularity.",
+    "FCP/SI run-to-run variance on Lighthouse-Lantern is normal (~100-200ms); the trend is unchanged."
+  ]
+}


### PR DESCRIPTION
Closes out Stages 12 and 13 with the actual prod numbers and brings AGENTS.md in line with the new CSS conventions Stage 13 introduced.

Lighthouse delta (post-Stage-10 -> post-Stage-13):
- Performance 0.97 -> 0.98
- Accessibility 0.99 -> 1.00 (Stage 12: SVGR aria-hidden)
- SEO 0.92 -> 1.00 (Stage 12: per-route canonical)
- LCP 2.6s (0.87) -> 2.2s (0.94)
- /skills stylesheets 12 -> 7

The critical-CSS-inline followup we'd flagged post-Stage-10 isn't warranted with LCP back at 0.94; RESULTS.md notes that explicitly.

AGENTS.md §6 now documents two CSS patterns:
- Pattern A: postcss-import inline (default for small components)
- Pattern B: Remix links() (lazy-loaded heavies only)

§14's component / route checklists default to Pattern A.