### PR TITLE
feat(skills): newest-first timeline + currency-ordered tech carousel

### DIFF
--- a/app/components/Carousel/index.tsx
+++ b/app/components/Carousel/index.tsx
@@ -15,6 +15,7 @@ import {
   Html,
   Js,
   Mongodb,
+  Nextjs,
   Nodejs,
   Playwright,
   Python,
@@ -38,32 +39,42 @@ const getClasses = getClassMaker(BLOCK);
 
 // Static module-level list — keys are the technology names so React can use
 // content-stable keys without paying for uuid generation on every render.
+//
+// Order: current-stack first (what I'm using day-to-day), then web
+// fundamentals, then tooling/test infra, then less-current/legacy. Tweak
+// when the daily stack shifts; the carousel auto-scrolls so first
+// items are seen most.
 const ICONS: { name: string; Icon: () => ReactElement }[] = [
-  { name: 'html', Icon: Html },
-  { name: 'css', Icon: Css },
-  { name: 'tailwind', Icon: Tailwind },
-  { name: 'js', Icon: Js },
+  // Current stack
+  { name: 'react', Icon: React },
   { name: 'ts', Icon: Ts },
+  { name: 'nextjs', Icon: Nextjs },
+  { name: 'nodejs', Icon: Nodejs },
   { name: 'python', Icon: Python },
   { name: 'django', Icon: Django },
-  { name: 'react', Icon: React },
-  { name: 'remix', Icon: Remix },
-  { name: 'redux', Icon: Redux },
-  { name: 'git', Icon: GitIcon },
   { name: 'graphql', Icon: Graphql },
-  { name: 'cypress', Icon: Cypress },
-  { name: 'playwright', Icon: Playwright },
+  { name: 'cloudflare', Icon: Cloudflare },
+  { name: 'remix', Icon: Remix },
+  // Web fundamentals
+  { name: 'html', Icon: Html },
+  { name: 'css', Icon: Css },
+  { name: 'js', Icon: Js },
+  { name: 'tailwind', Icon: Tailwind },
+  { name: 'sass', Icon: Sass },
+  // Tooling / testing / infra
   { name: 'storybook', Icon: Storybook },
-  { name: 'nodejs', Icon: Nodejs },
-  { name: 'axios', Icon: Axios },
+  { name: 'playwright', Icon: Playwright },
+  { name: 'cypress', Icon: Cypress },
+  { name: 'git', Icon: GitIcon },
+  { name: 'agile', Icon: AgileSoftware },
+  // Less current / legacy
+  { name: 'redux', Icon: Redux },
   { name: 'express', Icon: Express },
   { name: 'mongodb', Icon: Mongodb },
+  { name: 'axios', Icon: Axios },
   { name: 'vue', Icon: VueJs },
   { name: 'highcharts', Icon: Highcharts },
-  { name: 'agile', Icon: AgileSoftware },
-  { name: 'sass', Icon: Sass },
   { name: 'heroku', Icon: Heroku },
-  { name: 'cloudflare', Icon: Cloudflare },
 ];
 
 export default function Carousel() {

--- a/app/routes/skills._index/index.tsx
+++ b/app/routes/skills._index/index.tsx
@@ -98,7 +98,12 @@ export async function loader() {
   // a "neither type sufficiently overlaps" error.
   const typed = skillsData as unknown as skillsDataTypes;
 
-  const data = typed.WORK_ITEMS.map((item) => ({
+  // Reverse so the timeline reads newest-first. WORK_ITEMS in
+  // skills.json is authored chronologically (oldest first) — that
+  // ordering is preserved for getSkillChartData and yearsOfExp below
+  // (which treat WORK_ITEMS[0] as the career start). Only the
+  // displayed timeline array is reversed.
+  const data = [...typed.WORK_ITEMS].reverse().map((item) => ({
     // ids in JSON are numeric, but Timeline + the /skills/:uuid URL
     // both want strings; convert once here.
     id: String(item.id),

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -399,78 +399,32 @@
     }
   ],
   "SKILLS_IMG": [
-    {
-      "title": "HTML"
-    },
-    {
-      "title": "CSS"
-    },
-    {
-      "title": "Tailwind"
-    },
-    {
-      "title": "JavaScript"
-    },
-    {
-      "title": "TypeScript"
-    },
-    {
-      "title": "Python"
-    },
-    {
-      "title": "Django"
-    },
-    {
-      "title": "React"
-    },
-    {
-      "title": "Remix.run"
-    },
-    {
-      "title": "Redux"
-    },
-    {
-      "title": "Git"
-    },
-    {
-      "title": "GraphQL"
-    },
-    {
-      "title": "Cypress"
-    },
-    {
-      "title": "Playwright"
-    },
-    {
-      "title": "Storybook"
-    },
-    {
-      "title": "NodeJs"
-    },
-    {
-      "title": "Axios"
-    },
-    {
-      "title": "Express"
-    },
-    {
-      "title": "Mongodb"
-    },
-    {
-      "title": "Vue"
-    },
-    {
-      "title": "Highcharts"
-    },
-    {
-      "title": "Agile Development"
-    },
-    {
-      "title": "Sass"
-    },
-    {
-      "title": "Heroku"
-    }
+    { "title": "React" },
+    { "title": "TypeScript" },
+    { "title": "Next.js" },
+    { "title": "NodeJs" },
+    { "title": "Python" },
+    { "title": "Django" },
+    { "title": "GraphQL" },
+    { "title": "Cloudflare" },
+    { "title": "Remix.run" },
+    { "title": "HTML" },
+    { "title": "CSS" },
+    { "title": "JavaScript" },
+    { "title": "Tailwind" },
+    { "title": "Sass" },
+    { "title": "Storybook" },
+    { "title": "Playwright" },
+    { "title": "Cypress" },
+    { "title": "Git" },
+    { "title": "Agile Development" },
+    { "title": "Redux" },
+    { "title": "Express" },
+    { "title": "Mongodb" },
+    { "title": "Axios" },
+    { "title": "Vue" },
+    { "title": "Highcharts" },
+    { "title": "Heroku" }
   ],
   "EXTRA_ACTIVITIES": [
     {

--- a/tests/e2e/skills.spec.ts
+++ b/tests/e2e/skills.spec.ts
@@ -9,11 +9,15 @@ test.describe('Skills (/skills)', () => {
     await expect(
       page.getByRole('heading', { name: 'Work Experience', exact: true, level: 2 })
     ).toBeVisible();
-    // Globant is the first work item in skills.json — pin to its detail link
+    // Qubika (most recent role) is the topmost timeline entry post-Stage-24
+    // reversal — assert against it instead of Globant so the assertion
+    // doesn't depend on the IntersectionObserver having fired for off-screen
+    // entries (the react-vertical-timeline-component only mounts entries
+    // that have intersected the viewport).
     await expect(
       page
         .getByRole('link')
-        .filter({ hasText: /Globant/i })
+        .filter({ hasText: /Qubika/i })
         .first()
     ).toBeVisible();
     await expect(page.getByText(/Total years of experience/i)).toBeVisible();
@@ -57,13 +61,17 @@ test.describe('Skills (/skills)', () => {
 test.describe('Skill detail (/skills/:uuid)', () => {
   test('navigates from timeline card to detail page', async ({ page }) => {
     await page.goto('/skills');
+    // Qubika (most recent) is the topmost timeline card after Stage 24's
+    // reversal — using it instead of Globant avoids the
+    // IntersectionObserver-based lazy mount issue (see timeline-render
+    // test for the long version).
     await page
       .getByRole('link')
-      .filter({ hasText: /Globant/i })
+      .filter({ hasText: /Qubika/i })
       .first()
       .click();
     await expect(page).toHaveURL(/\/skills\/\d+/);
-    await expect(page.getByRole('heading', { name: /Globant/i, level: 1 })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Qubika/i, level: 1 })).toBeVisible();
     await expect(page.getByText(/Hire Date/i)).toBeVisible();
     await expect(page.getByText(/Role \/ Job Description/i)).toBeVisible();
   });


### PR DESCRIPTION
Friend feedback on /skills:

- Timeline reversed to read newest-job-first (Qubika at top, Globant at bottom). Implementation reverses only the displayed array; WORK_ITEMS[0] is preserved as the career-start anchor for the yearsOfExp calculation and getSkillChartData (both treat oldest- first). Net: career arc reads correctly while the chart math stays untouched.
- Carousel ICONS array regrouped by currency: current stack first (React, TS, Next.js, Node.js, Python, Django, GraphQL, Cloudflare, Remix), then web fundamentals (HTML, CSS, JS, Tailwind, Sass), then tooling/test/infra, then less-current/legacy. Adds Next.js to the strip (icon already existed in app/components/icons/).
- SKILLS_IMG (autocomplete suggestions) reordered to match the carousel grouping. Adds Next.js + Cloudflare so they're suggestable in the filter input, not just visible on the icon strip.
- E2E tests: assert against Qubika (now the topmost timeline entry) instead of Globant. The vertical-timeline component IntersectionObserver-mounts entries on scroll, so the bottom entry isn't reliably present in the DOM during a fast Playwright click — Qubika is always above the fold.