### PR TITLE
fix(layout): tablet breakpoint — sidebar nav at 768px, not 1076px

### DIFF
--- a/app/components/NavBar/style.css
+++ b/app/components/NavBar/style.css
@@ -106,7 +106,12 @@
   }
 }
 
-@media screen and (min-width: $desktop-small) {
+/*
+ * Sidebar layout activates at $bp-md (768px) — was $desktop-small
+ * (1076px). Tablet portrait now gets the left-rail nav instead of
+ * the bottom-stuck mobile pattern that overlaid mid-page content.
+ */
+@media screen and (min-width: $bp-md) {
   .navbar-component {
     &__special-anchor-container {
       display: flex;

--- a/app/routes/education._index/style.css
+++ b/app/routes/education._index/style.css
@@ -97,6 +97,13 @@
   }
 }
 
+/*
+ * Tablet portrait + landscape: cert cards stay 1-col (each is
+ * min-width 500px-ish, doesn't fit 2-col below 1024px content
+ * width). Degree cards stay stacked too — 60% width of a
+ * sub-1024px viewport leaves ~341px per card, too narrow for
+ * the title + summary.
+ */
 @media screen and (min-width: $desktop-small) {
   .education-route {
     &__degree-container {

--- a/app/styles/constants.js
+++ b/app/styles/constants.js
@@ -57,6 +57,29 @@ export default {
   'shadow-1': 'inset 0 -1px 0 #21262d',
 
   // Break points
+  //
+  // The legacy tokens ($mobile-small, $desktop-small, $desktop-medium)
+  // are mobile-first min-width queries — base styles target the
+  // smallest viewport, breakpoints add at larger sizes. Both naming
+  // (`mobile-small` is the *bigger-than-smallest-mobile* threshold)
+  // and coverage (no tablet stop between 497-1075px) are awkward.
+  //
+  // Tablet stop added below: $bp-md = 768px catches iPad portrait,
+  // every Android tablet, and narrow laptop windows. Old tokens
+  // retained — they still work — so each route can opt into the new
+  // breakpoint as it gets touched.
+  //
+  // Tailwind-aligned for source-readability:
+  //   bp-sm  640px   small phone landscape, large mobile
+  //   bp-md  768px   tablet portrait (iPad), large phones landscape
+  //   bp-lg  1024px  tablet landscape, small laptops
+  //   bp-xl  1280px  standard desktops
+  'bp-sm': '640px',
+  'bp-md': '768px',
+  'bp-lg': '1024px',
+  'bp-xl': '1280px',
+
+  // Legacy (still referenced by un-migrated CSS).
   'desktop-medium': '1296px',
   'desktop-small': '1076px',
   'mobile-small': '496px',

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -67,7 +67,13 @@ main {
   font-display: swap;
 }
 
-@media screen and (min-width: $desktop-small) {
+/*
+ * Switch from bottom-stuck mobile nav to left-rail sidebar at the
+ * tablet breakpoint ($bp-md = 768px) instead of the legacy
+ * $desktop-small (1076px). Lifts the NavBar overlay off mid-page
+ * content on iPad portrait + every Android tablet + narrow laptops.
+ */
+@media screen and (min-width: $bp-md) {
   body {
     grid-auto-flow: column;
     grid-template-columns: min-content 3fr;


### PR DESCRIPTION
Tackles TECH-DEBT.md item #1 (no tablet breakpoint).

The legacy breakpoint scale jumped from $mobile-small (496px) directly to $desktop-small (1076px). Everything between — iPad portrait at 768px, every Android tablet, narrow laptop windows — got the smallest- phone layout. The bottom-stuck mobile NavBar overlaid mid-page content on /skills, the bar chart squashed against a 320px-style column, and the timeline cards lost their alternating-side layout.

Changes:
- constants.js: add $bp-sm (640) / $bp-md (768) / $bp-lg (1024) / $bp-xl (1280) tokens. Tailwind-aligned values for source-readability. Old tokens retained — un-migrated CSS still works.
- style.css: body grid layout (sidebar nav + 3fr content) activates at $bp-md (768) instead of $desktop-small (1076).
- NavBar/style.css: sidebar layout block moved to $bp-md.
- education._index/style.css: comment-only — documents why cert cards stay 1-col below 1024px (they have min-width: 500px so 2-col would require shrinking them everywhere).

Other findings during the audit:
- Bar chart label squashing was transitively fixed: with the sidebar pulling content into ~568px at 768px, the chart no longer full-widths and the y-axis labels read correctly. No chart-specific change needed.
- /skills/:uuid, /, /education/:slug already worked at 768px once the sidebar shifted. Single-column stacks read cleanly.

Verified visually with screenshots at 768x1024 across all 5 routes. Visual baselines unchanged at desktop (1280×720) — both the new $bp-md and the legacy $desktop-small still apply at desktop width. Behavioural specs: 41/41 unit, 18/18 e2e.