### PR TITLE
fix(skills): autocomplete filter no longer dead-ends on 5 of 26 options

### DIFF
--- a/app/routes/skills._index/index.tsx
+++ b/app/routes/skills._index/index.tsx
@@ -10,7 +10,13 @@ import Input from '~/components/Input';
 import LoadingSpinner from '~/components/LoadingSpinner';
 import tenureHeatmapStyles from '~/components/TenureHeatmap/style.css?url';
 import timelineStyles from '~/components/Timeline/style.css?url';
-import { formatDate, getClassMaker, getSkillHeatmapData, mergeRouteMeta } from '~/utils/utils';
+import {
+  CHART_EXCLUDE,
+  formatDate,
+  getClassMaker,
+  getSkillHeatmapData,
+  mergeRouteMeta,
+} from '~/utils/utils';
 
 // Import the JSON server-side: Vite bakes it into the server bundle so
 // the loader doesn't have to do an HTTP round-trip to the static asset
@@ -77,10 +83,6 @@ type skillsDataTypes = {
     rol: string;
     skills: SkillEntryJson[];
   }[];
-  SKILLS_IMG: {
-    title: string;
-    img?: string;
-  }[];
   EXTRA_ACTIVITIES: {
     title: string;
     data: {
@@ -117,7 +119,20 @@ export async function loader() {
     skills: item.skills.map((s) => s.name),
   }));
 
-  const skills = typed.SKILLS_IMG.map((item) => item.title);
+  // Autocomplete suggestions derive from the actual skills attached to
+  // WORK_ITEMS, filtered through CHART_EXCLUDE (same set used by the
+  // chart + heatmap so generic descriptors like "Front End" / "Agile"
+  // don't appear as filter options). Previously a hand-maintained
+  // SKILLS_IMG list ran in parallel — names drifted ("NextJs" in
+  // WORK_ITEMS vs "Next.js" in suggestions) and ~5 of 26 suggestions
+  // matched nothing because the filter does a substring compare.
+  const skills = Array.from(
+    new Set(
+      typed.WORK_ITEMS.flatMap((w) => w.skills.map((s) => s.name)).filter(
+        (name) => !CHART_EXCLUDE.has(name)
+      )
+    )
+  ).sort();
 
   const heatmapData = getSkillHeatmapData(typed.WORK_ITEMS);
 

--- a/app/utils/utils.tsx
+++ b/app/utils/utils.tsx
@@ -103,8 +103,9 @@ export type WorkItemWithSkills = {
 };
 
 // Skills that appear in WORK_ITEMS as filter chips or generic descriptors,
-// not technologies — excluded from the chart.
-const CHART_EXCLUDE = new Set([
+// not technologies — excluded from the chart, the heatmap, and the
+// /skills autocomplete suggestions.
+export const CHART_EXCLUDE = new Set([
   'Front End',
   'Back End',
   'Agile',

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -41,7 +41,7 @@
           "start": "2018-08-01T00:00:00.000"
         },
         {
-          "name": ".Net",
+          "name": ".NET",
           "start": "2018-08-01T00:00:00.000",
           "end": "2019-08-01T00:00:00.000"
         },
@@ -145,7 +145,7 @@
           "end": "2021-08-01T00:00:00.000"
         },
         {
-          "name": "NodeJs",
+          "name": "Node.js",
           "start": "2020-12-01T00:00:00.000",
           "end": "2021-08-01T00:00:00.000"
         },
@@ -229,7 +229,7 @@
           "start": "2021-08-01T00:00:00.000"
         },
         {
-          "name": "Marklogic",
+          "name": "MarkLogic",
           "start": "2021-08-01T00:00:00.000"
         },
         {
@@ -336,7 +336,7 @@
           "start": "2022-04-01T00:00:00"
         },
         {
-          "name": "NextJs",
+          "name": "Next.js",
           "start": "2022-04-01T00:00:00",
           "end": "2025-10-01T00:00:00.000"
         },
@@ -401,34 +401,6 @@
         }
       ]
     }
-  ],
-  "SKILLS_IMG": [
-    { "title": "React" },
-    { "title": "TypeScript" },
-    { "title": "Next.js" },
-    { "title": "NodeJs" },
-    { "title": "Python" },
-    { "title": "Django" },
-    { "title": "GraphQL" },
-    { "title": "Cloudflare" },
-    { "title": "Remix.run" },
-    { "title": "HTML" },
-    { "title": "CSS" },
-    { "title": "JavaScript" },
-    { "title": "Tailwind" },
-    { "title": "Sass" },
-    { "title": "Storybook" },
-    { "title": "Playwright" },
-    { "title": "Cypress" },
-    { "title": "Git" },
-    { "title": "Agile Development" },
-    { "title": "Redux" },
-    { "title": "Express" },
-    { "title": "Mongodb" },
-    { "title": "Axios" },
-    { "title": "Vue" },
-    { "title": "Highcharts" },
-    { "title": "Heroku" }
   ],
   "EXTRA_ACTIVITIES": [
     {


### PR DESCRIPTION
The /skills page autocomplete suggestions were sourced from a hand-maintained SKILLS_IMG list in skills.json, but the actual filter ran substring matches against the skill names attached to WORK_ITEMS. The two lists drifted — picking some suggestions filtered nothing:

  Suggestion → WORK_ITEMS name  → matches?
  "Next.js"           "NextJs"         no
  "Node.js"  ─        "NodeJs"     ─   no  (5 of 26 broken)
  "Mongodb"           (absent)         no
  "Remix.run"         "Remix"          no
  "Agile Development" "Agile"          no

And 17 skills present on real work items ("Jest", "PostCSS", "Styled Components", ".Net"…) were absent from the suggestion list entirely.

**Fix:**
1. Normalize names in WORK_ITEMS to user-facing form: NextJs → Next.js, NodeJs → Node.js, .Net → .NET, Marklogic → MarkLogic.
2. Delete SKILLS_IMG from skills.json — it was the only consumer of those names, and an `img` field that was never populated.
3. Derive `skills` (the autocomplete suggestion list) from WORK_ITEMS[].skills, filtered through CHART_EXCLUDE (the same set getSkillHeatmapData and getSkillChartData already use to drop filter-chip terms like "Front End" / "Agile" / "Mentoring").

Net result: suggestion list went from 26 entries (5 broken) to 29 entries (0 broken). Adding a new skill to a work item now auto-populates the autocomplete; no second source of truth to keep in sync.

Visual baselines unchanged (renamed chips appear on /skills index, which is excluded from the visual suite per tests/e2e/README.md).