### PR TITLE
refactor: trim narration comments from CSS and route loaders

### DIFF
--- a/app/components/Card/style.css
+++ b/app/components/Card/style.css
@@ -1,32 +1,17 @@
 .card-component {
   display: flex;
   justify-content: center;
-  /* 8px (between $border-6 and $border-10) matches GitHub's own
-   * card radius — softer than 10px which read as toy-like next to
-   * the cleaner GitHub vocabulary. */
   border-radius: $border-8;
-  /* Surface (subtle lift over page bg in dark; same as page in
-   * light, anchored by --border-default). Theme-aware via the
-   * [data-theme] cascade in app/styles/style.css. */
   background-color: var(--bg-surface);
   color: var(--fg-base);
   border: 1px solid var(--border-default);
   flex-direction: column;
   overflow: hidden;
 
-  /* Card-internal h2 sits below section h2 in the visual hierarchy.
-   * Section h2 sizes are set in the /skills, /education, and detail
-   * route stylesheets — this is the smaller card-internal default. */
   & h2 {
     font-size: $font-20;
   }
 
-  /* Styleless was originally "no border" — that meant timeline
-   * cards floated as raw text against the page. Now that the
-   * design language gives every panel its own surface + border
-   * (mirroring how GitHub layers its UI), styleless keeps the
-   * bg + border and only relaxes the section-h2 sizing for the
-   * tighter timeline card. */
   &--styleless {
     & div h2 {
       font-size: $font-20;
@@ -44,10 +29,6 @@
 
   &__title-wrapper {
     text-align: center;
-    /* Header sits on --bg-elevated so it reads as a header band
-     * distinct from both the page bg and the card body. The
-     * hairline divider underneath reinforces the split for users
-     * with reduced color sensitivity. */
     background-color: var(--bg-elevated);
     box-shadow: inset 0 -1px 0 var(--border-default);
     padding: $space-16 $space-4;
@@ -61,9 +42,6 @@
     margin-bottom: $space-12;
   }
 
-  /* Bold prefix label for texts lines (e.g. "Rol:" before the role
-   * description on timeline cards). Same weight as the
-   * skills-label so the two read as siblings. */
   &__texts-label {
     font-weight: $weight-700;
   }
@@ -112,8 +90,6 @@
     border-radius: $border-10;
     background: var(--bg-elevated);
     color: var(--fg-base);
-    /* Monaspace Neon for tech/skill chips — same visual language
-     * as IDE labels, distinguishes them from prose. */
     font-family: 'Monaspace Neon', ui-monospace, 'SF Mono', monospace;
     font-size: $font-14;
     line-height: 1.4;
@@ -123,9 +99,6 @@
       background 120ms ease;
 
     &:hover {
-      /* --accent-muted is intentionally subtle: green-tinted
-       * highlight in dark, soft mint in light. Hints at
-       * interactivity without screaming. */
       border-color: var(--accent);
       background: var(--accent-muted);
     }

--- a/app/components/Carousel/style.css
+++ b/app/components/Carousel/style.css
@@ -22,11 +22,8 @@
     text-transform: uppercase;
   }
 
-  /* Forward-looking groups (Learning, Future) recolor their title
-   * in accent green so the section reads as "in progress /
-   * aspirational" at a glance. Defined after the base
-   * &__group-title rule above so Stylelint's no-descending-specificity
-   * rule is satisfied (more-specific selector follows the base). */
+  /* Defined after the base &__group-title above so stylelint's
+   * no-descending-specificity rule is satisfied. */
   &__group--learning &__group-title,
   &__group--future &__group-title {
     color: var(--accent);
@@ -62,10 +59,6 @@
     }
   }
 
-  /* Forward-looking chips (Learning + Future): dashed accent
-   * border, transparent fill so the dashes read against the card
-   * surface, accent text. The two variants share the visual
-   * treatment — only the group-title label distinguishes them. */
   &__item--learning,
   &__item--future {
     border: 1px dashed var(--accent);
@@ -78,16 +71,9 @@
   }
 }
 
-/* From tablet up: 2-column group layout. `auto` columns size each
- * group to its widest chip (instead of `1fr` which would force both
- * columns to the widest content's width). This keeps the card from
- * ballooning when one chip — like the master's-degree label — is
- * substantially longer than the rest.
- *
- * No 4-column escalation at $bp-lg: TechGrid sits in the
- * side-by-side row with the heatmap on /skills, where 4 columns
- * inside that already-narrow track would squeeze chips onto
- * multiple lines. 2 columns reads cleanly across tablet → desktop. */
+/* `auto` columns (not `1fr`) so each group sizes to its widest chip
+ * instead of stretching to the longest entry's width — keeps the card
+ * from ballooning when one chip is substantially longer. */
 @media screen and (min-width: $bp-md) {
   .carousel-component {
     grid-template-columns: repeat(2, auto);

--- a/app/components/NavBar/style.css
+++ b/app/components/NavBar/style.css
@@ -1,15 +1,10 @@
-/* ThemeToggle CSS inlined here via postcss-import so its styles ship
- * as part of the NavBar's first-paint chrome on every route. */
 @import '../ThemeToggle/style.css';
 
 .navbar-component {
   display: flex;
   flex-direction: column;
-  /* --bg-nav is its own token (not --bg-surface) so the rail can
-   * sit on a tone DISTINCT from the card surface — otherwise the
-   * sidebar and any cards in the main content merge into one
-   * visual block. Border on the inner edge keeps the divide crisp
-   * at every theme. */
+  /* --bg-nav (not --bg-surface) so the rail sits on a tone distinct
+   * from any cards in the main content. */
   background: var(--bg-nav);
   color: var(--fg-base);
   min-height: 100%;
@@ -17,19 +12,13 @@
   z-index: 2;
   position: sticky;
   bottom: 0;
-  /* Mobile (bottom-stuck nav): top hairline separates nav from
-   * content above. Use inset box-shadow rather than `border-top` so
-   * the 1px doesn't add to the navbar's box height — the body grid
-   * is sized to exactly viewport height + nav height; an extra 1px
-   * border would overflow and trigger a vertical scroll. Desktop
-   * switches to a right border via media query (it's fixed-position
-   * there, so the extra px doesn't affect layout). */
+  /* `box-shadow: inset` instead of `border-top`: the body grid is
+   * sized to viewport-height + nav-height; an extra 1px border would
+   * overflow and trigger a vertical scroll. Desktop uses border-right. */
   box-shadow: inset 0 1px 0 var(--border-default);
   /* Stop hover/focus pills from overflowing the rail's right edge. */
   overflow: hidden;
 
-  /* Mobile: avatar hidden — the bottom-stuck nav doesn't have the
-   * vertical real estate. Desktop sidebar shows it (see media query). */
   &__avatar-row {
     display: none;
   }
@@ -55,10 +44,9 @@
       justify-content: center;
       align-items: center;
       height: 100%;
-      /* Override the user-agent default link color (purple/blue) so
-       * `currentColor` in the SVG icons inherits the theme text
-       * color. The LinkedIn icon's brand-blue fill stays intact
-       * because it's hardcoded in the SVG. */
+      /* Override the default link color so currentColor in the SVG
+       * icons inherits the theme text color. LinkedIn's brand-blue
+       * fill is hardcoded in its SVG and stays intact. */
       color: var(--fg-base);
     }
   }
@@ -99,9 +87,6 @@
     }
   }
 
-  /* Mobile bottom-nav links: vertical icon-over-label layout, like
-   * Instagram/TikTok. Tighter than the previous text-only row and
-   * the icon makes the section glanceable at a thumb. */
   &__nav-link {
     display: flex;
     flex-direction: column;
@@ -119,9 +104,8 @@
       background: var(--bg-elevated);
     }
 
-    /* Inset focus ring — can't overflow the rail (outline-based
-     * rings on the previous version bled into the content area on
-     * hover). */
+    /* Inset focus ring stays inside the rail — outline-based rings
+     * bled into the content area on hover. */
     &:focus-visible {
       outline: none;
       box-shadow: inset 0 0 0 2px var(--accent);
@@ -134,12 +118,9 @@
     flex-shrink: 0;
   }
 
-  /* Active state — current route. Soft accent background carries
-   * the "this is selected" signal; text stays --fg-base so it reads
-   * neutrally instead of neon-green-on-dark-green (which the
-   * previous --accent text rendered as). The --accent itself only
-   * appears as the left stripe (desktop) so the brand color still
-   * marks the row, just less aggressively. */
+  /* Active route — soft accent bg + neutral text. --accent itself is
+   * reserved for the desktop left stripe so the brand color marks the
+   * row without overpowering it. */
   &__nav-link--active {
     background: var(--accent-muted);
     color: var(--fg-base);
@@ -147,33 +128,18 @@
   }
 }
 
-/*
- * Sidebar layout activates at $bp-md (768px) — was $desktop-small
- * (1076px). Tablet portrait now gets the left-rail nav instead of
- * the bottom-stuck mobile pattern that overlaid mid-page content.
- */
 @media screen and (min-width: $bp-md) {
   .navbar-component {
-    /* Sidebar mode: drop the mobile top-hairline (cleared via the
-     * box-shadow override below) and add a real right border so the
-     * sidebar visibly cuts away from the content. Width is fixed
-     * via min-width so the content area has a stable left edge.
-     * The mobile box-shadow gets overridden by the inner-element
-     * shadows below — this top-level shadow is redundant on
-     * desktop. */
+    /* Sidebar mode: clear the mobile top hairline, add a real right
+     * border for the content gutter. */
     box-shadow: none;
     border-right: 1px solid var(--border-default);
     min-width: $space-200;
 
-    /* Pin to the viewport top while the body scrolls beneath. We
-     * use `position: fixed` instead of `position: sticky` because
-     * body's grid layout (display: grid + grid-template-columns)
-     * doesn't establish a sticky-cooperative parent in all browsers
-     * — sticky kept scrolling off-screen on long pages like /skills.
-     * Fixed lets us anchor to the viewport directly.
-     *
-     * The grid track for the nav still claims its 200px width
-     * (min-width on the rail), so content doesn't slide under it. */
+    /* `position: fixed` not `sticky` — body's grid layout doesn't
+     * establish a sticky-cooperative parent in all browsers, so
+     * sticky scrolled off on long pages like /skills. The grid track
+     * still claims 200px so content doesn't slide under. */
     position: fixed;
     top: 0;
     bottom: auto;
@@ -181,14 +147,10 @@
     height: 100vh;
     max-height: 100vh;
     width: $space-200;
-    /* X-axis still clipped to keep hover pills inside the rail; Y
-     * scrolls if the rail's content (avatar + toggle + buttons +
-     * eventual additions) ever exceeds the viewport height. */
+    /* X clipped to contain hover pills; Y scrolls if rail content
+     * ever exceeds viewport height. */
     overflow: hidden auto;
 
-    /* Avatar visible at desktop only. Round, matches the rail's
-     * accent — bordered in --accent-soft for a subtle highlight
-     * that reads as "this is a person, not a logo". */
     &__avatar-row {
       display: flex;
       justify-content: center;
@@ -217,11 +179,6 @@
       flex: 1;
     }
 
-    /* Vertical padding only — letting the active pill stretch
-     * edge-to-edge horizontally reads cleaner against the rail than
-     * the previous "inset chip" look. The 12px top/bottom keeps the
-     * top/bottom buttons from butting up against the social-row
-     * divider above and the (empty) bottom of the rail. */
     &__main-buttons {
       width: 100%;
 
@@ -253,10 +210,7 @@
       height: $space-20;
     }
 
-    /* Desktop active state — soft accent background + neutral text
-     * + a 3px left stripe in --accent. The base rule above sets the
-     * bg + text; this block adds the stripe and the relative
-     * positioning needed for it. */
+    /* Desktop active state adds a 3px left stripe to the base bg/text. */
     &__nav-link--active {
       position: relative;
       height: 100%;

--- a/app/components/TenureHeatmap/style.css
+++ b/app/components/TenureHeatmap/style.css
@@ -6,20 +6,15 @@
   background-color: var(--bg-surface);
   border: 1px solid var(--border-default);
   border-radius: $border-8;
-  /* Tight padding — the grid carries its own breathing room via the
-   * 3px gap between cells. */
   padding: $space-16;
-  /* Allow horizontal scroll on narrow viewports rather than squashing
-   * the grid — a CV with 9+ years × 14 skills would otherwise crush
-   * cells to sub-pixel widths on phones. */
+  /* Horizontal scroll over squashing — cells would otherwise crush to
+   * sub-pixel widths on narrow viewports with 9+ year columns. */
   overflow-x: auto;
 
   &__grid {
     display: grid;
-    /* First column = skill label, then one column per year. Mobile
-     * uses 22px tracks (legibility on small screens); desktop drops
-     * to 14px to match GitHub's contribution-graph density. The
-     * --years-count is set inline by the React component. */
+    /* First column = skill label, rest = one per year. --years-count
+     * is set inline by the React component. */
     grid-template-columns: minmax(90px, 110px) repeat(var(--years-count), 22px);
     gap: 3px;
     align-items: center;
@@ -59,13 +54,9 @@
     }
   }
 
-  /* GitHub contribution-graph green ramp. Level-0 is the empty
-   * surface, levels 1-4 climb in saturation + brightness. Same hex
-   * set works in both themes — the cell sits on --bg-surface, which
-   * has enough contrast either way. */
-  /* Empty cell (level 0) sits a hair above --bg-elevated so the
-   * grid bounds read clearly against the card surface in dark
-   * mode — without the bump it merged into the chip surface. */
+  /* GitHub contribution-graph green ramp. Level-0 background is bumped
+   * a hair above --bg-elevated in dark mode so the grid bounds read
+   * clearly against the card surface (lower values merged in). */
   &__cell--level-0 {
     background: #2a3530;
     border-color: var(--border-default);
@@ -114,9 +105,6 @@
     margin: 0 $space-4;
   }
 
-  /* Tiny link-like toggle — matches GitHub's "Show more" pattern.
-   * Sits on its own at the bottom-right of the heatmap card so it
-   * reads as metadata, not a primary CTA. */
   &__toggle {
     align-self: flex-end;
     background: transparent;
@@ -138,18 +126,13 @@
   }
 }
 
-/* Desktop: cells back to GitHub-density 14px (mobile keeps 22px so
- * the grid doesn't crush on small screens). Skill column also gets
- * a wider min so the longer skill names breathe. */
+/* Desktop: 14px cells (GitHub density). Mobile keeps 22px for legibility. */
 @media screen and (min-width: $bp-md) {
   .tenure-heatmap__grid {
     grid-template-columns: minmax(110px, 140px) repeat(var(--years-count), 14px);
   }
 }
 
-/* Light mode tweak: the level-1 dark green is too close to the page bg
- * in dark mode but reads cleanly in light. Bump the level-0 cell so
- * the empty cells are clearly distinct from the lowest-activity ones. */
 [data-theme='light'] .tenure-heatmap {
   &__cell--level-0 {
     background: #ebedf0;

--- a/app/components/ThemeToggle/style.css
+++ b/app/components/ThemeToggle/style.css
@@ -1,21 +1,8 @@
-/*
- * Sliding sun/moon toggle. The knob (an absolutely-positioned green
- * pill) sits behind the icons and slides between them on click.
- * Active icon picks up a contrasting color via the --sun / --moon
- * modifier set on the root.
- *
- * Layout: 2-cell flex with the icons centered in each half. The
- * knob is 50% of the track width and translates between left and
- * right halves via CSS transition.
- */
 .theme-toggle {
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
-  /* 150px wide so the slider reads as a real toggle, not a chip.
-   * Each half is ~75px → the sun and moon sit comfortably with
-   * room to breathe inside the green knob. */
   width: 150px;
   height: 1.75rem;
   padding: 2px;
@@ -33,9 +20,6 @@
     outline: none;
   }
 
-  /* Icons sit on top of the knob — z-index 1 so they paint over it.
-   * Each takes half the track width so the knob's translateX from
-   * 0 → 100% lands them squarely under each one. */
   &__icon {
     position: relative;
     z-index: 1;
@@ -53,9 +37,6 @@
     }
   }
 
-  /* Knob — the sliding green pill underneath the icons. Uses
-   * percentage-based transform so the slide distance scales with
-   * the track width, no magic-number pixel math. */
   &__knob {
     position: absolute;
     top: 2px;
@@ -69,8 +50,6 @@
     pointer-events: none;
   }
 
-  /* Sun position: knob anchored left, sun icon contrasts white-on-
-   * green, moon icon dims to muted. */
   &--sun {
     & .theme-toggle__knob {
       transform: translateX(0);
@@ -85,9 +64,6 @@
     }
   }
 
-  /* Moon position: knob slides right, moon icon contrasts, sun dims.
-   * SSR default lives here since the inline theme-init script lands
-   * dark mode unless the user has already opted into light. */
   &--moon {
     & .theme-toggle__knob {
       transform: translateX(100%);
@@ -103,9 +79,6 @@
   }
 }
 
-/* Honour reduced-motion: skip the slide. Color crossfade still
- * happens since it's a low-motion change, but the knob just snaps
- * between positions. */
 @media (prefers-reduced-motion: reduce) {
   .theme-toggle__knob {
     transition: none;

--- a/app/components/Timeline/style.css
+++ b/app/components/Timeline/style.css
@@ -92,16 +92,9 @@
     }
   }
 
-  /*
-   * Center the date label on the same horizontal line as the green
-   * check icon (which sits at `top: 30px` for the 60×60 icon in
-   * two-columns mode). Library default is `top: 6px` plus a `.8em`
-   * vertical padding, which leaves the date sitting noticeably higher
-   * than the icon center.
-   *
-   * Also force `opacity: 1` because the library dims the date to 0.7
-   * by default, and we already control color via var(--fg-base).
-   */
+  /* Re-center the date on the icon's horizontal line — library
+   * default sits .8em higher and dims to opacity 0.7 (we already own
+   * color via the token). */
   &
     .vertical-timeline--two-columns
     .vertical-timeline-element-content
@@ -109,8 +102,6 @@
     top: 24px;
     padding: 0;
     opacity: 1;
-    /* Mono date label — IDE-like, sits next to the icon ring as
-     * a metadata stamp rather than prose. */
     font-family: 'Monaspace Neon', ui-monospace, 'SF Mono', monospace;
     color: var(--fg-muted);
   }

--- a/app/routes/education.$slug/index.tsx
+++ b/app/routes/education.$slug/index.tsx
@@ -29,8 +29,6 @@ type DegreeData = {
   skills: string[];
 };
 
-// slug → key in education.json. Add a new entry here when a new clickable
-// degree is added.
 const SLUG_MAP: Record<string, 'degree' | 'associateDegree'> = {
   degree: 'degree',
   'associate-degree': 'associateDegree',

--- a/app/routes/education.$slug/style.css
+++ b/app/routes/education.$slug/style.css
@@ -1,5 +1,3 @@
-/* Card CSS is inlined here so /education/:slug ships one stylesheet
- * instead of two. postcss-import resolves at build. */
 @import '../../components/Card/style.css';
 
 .education-id-route {
@@ -31,8 +29,6 @@
   }
 
   &__description-container {
-    /* Cap by readable line length on ultrawide so body text doesn't
-     * stretch past the comfortable reading length. */
     max-width: 65ch;
     margin: 0 auto;
     width: 100%;

--- a/app/routes/education._index/index.tsx
+++ b/app/routes/education._index/index.tsx
@@ -7,10 +7,6 @@ import { FormattedMessage } from 'react-intl';
 import Card from '~/components/Card';
 import { formatDate, getClassMaker, mergeRouteMeta } from '~/utils/utils';
 
-// Import the JSON server-side: Vite bakes it into the server bundle so
-// the loader doesn't have to do an HTTP round-trip to the static asset
-// at /data/education.json on every request. The asset is still served
-// publicly via the `/data/*` exclude in public/_routes.json.
 import educationData from '../../../public/data/education.json';
 import styles from './style.css?url';
 
@@ -36,11 +32,6 @@ type Certification = {
 };
 
 export async function loader() {
-  // Widen the inferred type: TS reads the JSON literal and produces a
-  // discriminated union based on which entries have `url`, so
-  // `cert.url` isn't accessible without narrowing. Casting up to a
-  // single shape with `url?: string` matches the old behavior and
-  // keeps the consumer code simple.
   return {
     degree: educationData.degree,
     associateDegree: educationData.associateDegree,
@@ -78,7 +69,6 @@ export default function Skills() {
   };
 
   const certificationsCards = certifications.map((certification) => ({
-    // institution is unique across certifications in education.json — stable key.
     key: certification.institution,
     title: certification.title,
     texts: [

--- a/app/routes/education._index/style.css
+++ b/app/routes/education._index/style.css
@@ -1,5 +1,3 @@
-/* Card CSS is inlined here so /education ships one stylesheet instead
- * of two. postcss-import resolves the path at build time. */
 @import '../../components/Card/style.css';
 
 .education-route {
@@ -9,8 +7,6 @@
   gap: $space-20;
   width: 100%;
 
-  /* Section headings render larger than card-internal headings so the
-   * page hierarchy is "page > section > card title" not flat. */
   & > div > h2 {
     font-size: $font-24;
   }
@@ -47,9 +43,8 @@
   &__card-link {
     text-decoration: none;
     color: inherit;
-    /* Flex so the wrapper stretches to fill the row height — keeps the
-     * two degree cards equal-height when their summaries differ in
-     * line count on desktop. */
+    /* Stretch to row height so degree cards stay equal-height when
+     * their summaries differ in line count. */
     display: flex;
     transition:
       transform 120ms ease,
@@ -60,8 +55,6 @@
       transform: translateY(-2px);
 
       .card-component {
-        /* Soft accent halo on hover. rgba() with a fixed accent
-         * tone reads as "elevated" against either theme bg. */
         box-shadow: 0 4px 16px rgba(15, 191, 62, 0.25);
       }
 
@@ -101,13 +94,6 @@
   }
 }
 
-/*
- * Tablet portrait + landscape: cert cards stay 1-col (each is
- * min-width 500px-ish, doesn't fit 2-col below 1024px content
- * width). Degree cards stay stacked too — 60% width of a
- * sub-1024px viewport leaves ~341px per card, too narrow for
- * the title + summary.
- */
 @media screen and (min-width: $desktop-small) {
   .education-route {
     &__degree-container {

--- a/app/routes/skills.$uuid/index.tsx
+++ b/app/routes/skills.$uuid/index.tsx
@@ -20,25 +20,9 @@ export const meta: MetaFunction<typeof loader> = (args) =>
 const BLOCK = 'skills-id-route';
 const getClasses = getClassMaker(BLOCK);
 
-// Display dimensions for each company logo, fed to <img width> /
-// <img height> to reserve layout space (fixes CLS).
-//
-// These values are NOT the intrinsic webp dimensions — most logos are
-// intentionally narrowed in height so the <img> renders as a banner
-// rather than its full square / portrait aspect (browsers infer the
-// aspect-ratio from these attributes). The width matches the source
-// file; the height is hand-picked per logo for the banner crop.
-//
-// Real intrinsics for reference (decoded from public/assets/img/*.webp):
-//   unsta2:     968×519   → narrowed to 968×400
-//   coderhouse: 976×272   → unchanged
-//   globant:    3000×2000 → narrowed to 3000×200
-//   cliengo:    999×300   → narrowed to 999×200
-//   endava:     541×184   → unchanged
-//   qubika:     800×600   → narrowed to 800×400
-//
-// If a logo is swapped, re-pick its banner height; the source file's
-// own dimensions are not the authority.
+// Hand-picked banner dimensions per logo (height is narrowed from the
+// source webp to render the image as a banner rather than its full
+// aspect). Re-pick if a logo is swapped.
 const LOGO_DIMS: Record<string, { width: number; height: number }> = {
   'unsta2.webp': { width: 968, height: 400 },
   'coderhouse.webp': { width: 976, height: 272 },
@@ -49,18 +33,14 @@ const LOGO_DIMS: Record<string, { width: number; height: number }> = {
 };
 const FALLBACK_DIMS = { width: 1000, height: 500 };
 
-// Title → image filename overrides for jobs whose `.toLowerCase().webp`
-// derivation doesn't yield a real file. Add a row here when a job has
-// no matching file in public/assets/img/ — for example "Professor
-// (part-time)" → unsta2.webp because the institution's name is the
-// stem, not the role title.
+// Title → filename overrides for jobs whose `${title.toLowerCase()}.webp`
+// derivation doesn't yield a real file (institution name as stem
+// instead of role title).
 const IMAGE_OVERRIDES: Record<string, string> = {
   'professor (part-time)': 'unsta2.webp',
   teacher: 'coderhouse.webp',
 };
 
-// Validate + parse once per worker boot. See skills._index for the
-// rationale; this route reads from the same cached payload.
 const SKILLS = loadSkills(skillsJson);
 
 export async function loader({ params }: LoaderFunctionArgs) {
@@ -127,11 +107,6 @@ export default function UuidIndex() {
       <h1 className={getClasses('title')}>{title}</h1>
       <div className={getClasses('main-container')}>
         <div className={getClasses('img-container')}>
-          {/* Logo is above-the-fold on this route (the page is the company
-           * detail) — eager-load so the banner shows immediately. Lazy
-           * here also broke the visual-regression spec: the lazy image
-           * delayed layout past the screenshot capture, so the rendered
-           * page measured ~600px shorter than its final height. */}
           <img
             src={imagePath}
             alt={title}

--- a/app/routes/skills.$uuid/style.css
+++ b/app/routes/skills.$uuid/style.css
@@ -1,5 +1,3 @@
-/* Card CSS is inlined here so /skills/:uuid ships one stylesheet
- * instead of two. postcss-import resolves the path at build time. */
 @import '../../components/Card/style.css';
 
 .skills-id-route {

--- a/app/routes/skills._index/index.tsx
+++ b/app/routes/skills._index/index.tsx
@@ -23,14 +23,8 @@ import {
 import skillsJson from '../../../public/data/skills.json';
 import styles from './style.css?url';
 
-// Manual CSS preload pattern for code-split components: TenureHeatmap,
-// Carousel, and Timeline are JS-lazy-loaded below, but their CSS is
-// pulled in as `?url` strings (no module evaluation, no chunk
-// coupling) and piped into Remix's <Links> via the route's `links()`.
-// We deliberately don't `import { links as xLinks } from '...'` — doing
-// so would make Vite treat the module as statically imported, defeating
-// the `lazy()` chunk split.
-
+// CSS for lazy components is imported as `?url` strings — a static
+// `import { links } from '...'` would defeat the lazy chunk split.
 export const links = () => [
   { rel: 'stylesheet', href: carouselStyles },
   { rel: 'stylesheet', href: tenureHeatmapStyles },
@@ -53,34 +47,19 @@ export const meta: MetaFunction = (args) =>
 const BLOCK = 'skills-route';
 const getClasses = getClassMaker(BLOCK);
 
-// Validate + parse the JSON once at module load. On a Cloudflare Pages
-// Function the module is reused across requests, so this runs once per
-// worker boot. A malformed skills.json crashes the worker with a
-// pretty-printed error pointing at the offending field.
+// Validated + derived once per worker boot. A malformed skills.json
+// throws a pretty-printed error pointing at the offending field.
 const SKILLS = loadSkills(skillsJson);
-
-// Heatmap data + autocomplete suggestions are pure functions of the
-// static SKILLS payload. Compute once at module scope; the loader just
-// hands the references to Remix.
 const HEATMAP_DATA = getSkillHeatmapData(SKILLS);
 const SUGGESTIONS = getSkillSuggestions(SKILLS);
-
-// Newest-job-first card list for the timeline. WORK_ITEMS is authored
-// chronologically (oldest first); reverse for display, derive the
-// per-card chip list from SKILLS via getSkillsForJob.
 const TIMELINE_CARDS = [...SKILLS.WORK_ITEMS].reverse().map((item) => ({
-  // Timeline + the /skills/:uuid URL want strings; convert once here.
   id: String(item.id),
   title: item.title,
   date: formatDate(item.startDate, item.endDate ?? undefined),
   texts: [item.rol],
-  // intl id — Card resolves it via formatMessage so the label
-  // tracks the active locale ("Role:" en / "Rol:" es).
   textsLabel: 'ROLE',
   skills: getSkillsForJob(SKILLS, item.id),
 }));
-
-// Career start = first WORK_ITEM as authored (chronological order).
 const YEARS_OF_EXP = formatDate(SKILLS.WORK_ITEMS[0].startDate, undefined, 'fullYearMonth');
 
 export async function loader() {
@@ -148,9 +127,6 @@ export default function Skills() {
           <FormattedMessage id="TECHNOLOGIES" />
         </h2>
         <div className={getClasses('skills-and-tools-grid')}>
-          {/* Heatmap left, TechGrid right on desktop — the heatmap is
-           * the more visually distinctive surface and earns the
-           * primary read-position. Both stack on mobile. */}
           <Suspense fallback={<LoadingSpinner />}>
             <LazyTenureHeatmap data={heatmapData} />
           </Suspense>

--- a/app/routes/skills._index/style.css
+++ b/app/routes/skills._index/style.css
@@ -1,7 +1,3 @@
-/* Card / Input / LoadingSpinner CSS is inlined here so /skills ships
- * one route stylesheet instead of four. postcss-import resolves the
- * paths at build time. Button is already inlined into the global
- * stylesheet via app/styles/style.css. */
 @import '../../components/Card/style.css';
 @import '../../components/Input/style.css';
 @import '../../components/LoadingSpinner/style.css';
@@ -42,8 +38,6 @@
       text-align: center;
 
       &__main-text-wrapper {
-        /* Mono numeric for the headline figure — reads as a stat
-         * card rather than a sentence. */
         font-family: 'Monaspace Neon', ui-monospace, 'SF Mono', monospace;
         font-size: $font-30;
         font-weight: $weight-700;
@@ -60,11 +54,6 @@
     width: 100%;
   }
 
-  /* Mobile: TechGrid on top, TenureHeatmap below (column flow).
-   * Desktop: side-by-side via the bp-lg media query at the bottom
-   * of this file. The heatmap sits in a fixed-width track (it
-   * doesn't benefit from extra width since cells are pinned at
-   * 14px), and the TechGrid takes the remaining space. */
   &__skills-and-tools-grid {
     display: flex;
     flex-direction: column;
@@ -148,9 +137,6 @@
       }
     }
 
-    /* Side-by-side: heatmap hugs its grid (it doesn't gain anything
-     * from extra width), TechGrid takes the rest. Centered as a
-     * group when the row has unused width on wide viewports. */
     &__skills-and-tools-grid {
       flex-direction: row;
       gap: $space-20;

--- a/app/routes/style.css
+++ b/app/routes/style.css
@@ -1,5 +1,3 @@
-/* DownloadBtn CSS is inlined here so / ships one stylesheet instead
- * of two. postcss-import resolves the path at build time. */
 @import '../components/DownloadBtn/style.css';
 
 .home-route {
@@ -7,12 +5,9 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  /* Fill the available viewport so the welcome copy + download
-   * button center vertically. --nav-h subtracts the mobile bottom-
-   * stuck navbar's claimed height (so the body doesn't end up
-   * taller than the screen and trigger a scroll); on desktop
-   * --nav-h resolves to 0 since the nav is fixed-position and
-   * doesn't claim viewport vertical space. */
+  /* Fill the visible viewport, minus the bottom-nav height on mobile.
+   * --nav-h is 0 at $bp-md (nav is fixed-position there, claims no
+   * vertical space). */
   min-height: calc(100vh - var(--nav-h));
   text-align: center;
   white-space: pretty;
@@ -21,9 +16,6 @@
     font-size: $font-20;
   }
 
-  /* 16px floor matches the browser default for body text and the WCAG
-   * recommendation. Desktop bumps the h1 only (see media query); body
-   * stays at 16px on every viewport. */
   p {
     font-size: $font-16;
   }
@@ -39,10 +31,6 @@
     font-weight: bold;
 
     a {
-      /* Accent green so the in-line link visibly stands out from
-       * the body sentence around it — matches GitHub's link
-       * vocabulary (link color = brand accent) instead of the
-       * site's foreground neutral. */
       color: var(--accent);
       transition:
         color 0.2s,

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -1,66 +1,37 @@
 /* stylelint-disable font-family-name-quotes */
 
-/* NavBar CSS is inlined into this global stylesheet via postcss-import
- * so its first-paint chrome ships with the rest of the global styles. */
 @import '../components/NavBar/style.css';
 
-/*
- * Theme-aware tokens. Default cascade applies the dark palette;
- * [data-theme='light'] swaps each variable to its light counterpart.
- * The data-theme attribute is set by an inline blocking <script> in
- * app/root.tsx before paint to avoid FOUC.
- *
- * GitHub brand palette source values live in app/styles/constants.js
- * as $gray-1..6 and $green-1..6.
- */
-/*
- * GitHub-style two-layer surface model:
- *   --bg-base      page background
- *   --bg-surface   card / nav rail (subtle lift in dark, same as page in light)
- *   --bg-elevated  chip / hover state (one tier above the card body)
- *
- * Cards are defined by their VISIBLE BORDER, not by a heavy
- * background fill. Card headers sit flush with the card body —
- * they're distinguished by typography + a hairline divider, not by
- * a separate bg. Mirrors github.com's own UI so the visual
- * vocabulary the user expects from "GitHub palette" actually shows.
- *
- * Light mode: page is pure white, card is also pure white,
- * everything is anchored by `--border-default`. This is GitHub's
- * actual approach — relying on shading to separate cards in light
- * mode would either look muddy (gray-on-gray) or harsh (gray-on-
- * white). Border-defined surfaces solve both.
- */
+/* Theme-aware tokens. The data-theme attribute is set by an inline
+ * blocking <script> in app/root.tsx before paint to avoid FOUC. */
 :root {
-  --bg-base: $gray-6; /* page background — process black */
-  --bg-surface: $surface-card-dark; /* card body */
-  --bg-nav: $surface-nav-dark; /* nav rail — own tone, distinct from cards */
-  --bg-elevated: $surface-elevated-dark; /* chips / hover */
-  --fg-base: $gray-1; /* primary text */
-  --fg-muted: $gray-3; /* body muted, dates */
-  --fg-faint: $gray-4; /* disabled, decorative */
-  --border-default: $border-card-dark; /* visible on --bg-surface */
-  --border-emphasis: $gray-4; /* hover border */
-  --accent: $green-4; /* primary accent (GitHub Green) */
-  --accent-soft: $green-3; /* hover/highlight */
-  --accent-muted: $green-6; /* accent backgrounds (dark) */
+  --bg-base: $gray-6;
+  --bg-surface: $surface-card-dark;
+  --bg-nav: $surface-nav-dark;
+  --bg-elevated: $surface-elevated-dark;
+  --fg-base: $gray-1;
+  --fg-muted: $gray-3;
+  --fg-faint: $gray-4;
+  --border-default: $border-card-dark;
+  --border-emphasis: $gray-4;
+  --accent: $green-4;
+  --accent-soft: $green-3;
+  --accent-muted: $green-6;
 
   /* Height the bottom-stuck mobile nav claims from the viewport.
-   * Routes that want to fill the viewport (Home) subtract this from
-   * their min-height so the body doesn't end up taller than the
-   * screen and trigger an unnecessary scroll. Overridden to 0 at
-   * $bp-md where the nav becomes a fixed-position sidebar that
-   * doesn't claim viewport vertical space. */
+   * Home subtracts this from its min-height so the body doesn't end
+   * up taller than the screen. Overridden to 0 at $bp-md where the
+   * nav becomes a fixed-position sidebar. */
   --nav-h: 148px;
 
   color-scheme: dark;
 }
 
 [data-theme='light'] {
-  --bg-base: $surface-page-light; /* canvas-subtle #f6f8fa */
-  --bg-surface: $surface-card-light; /* card — soft off-white */
-  --bg-nav: $surface-nav-light; /* nav rail */
-  --bg-elevated: $surface-elevated-light; /* chip/hover lift */
+  --bg-base: $surface-page-light;
+  --bg-surface: $surface-card-light;
+  --bg-nav: $surface-nav-light;
+  --bg-elevated: $surface-elevated-light;
   --fg-base: $gray-6;
   --fg-muted: $gray-4;
   --fg-faint: $gray-3;
@@ -86,7 +57,6 @@ body {
   color: var(--fg-base);
   background: var(--bg-base);
   font-family: 'Roboto', sans-serif;
-  /* Smooth the palette swap when the user toggles theme. */
   transition:
     background-color 200ms ease,
     color 200ms ease;
@@ -100,13 +70,8 @@ main {
   padding: 0 $space-4;
 }
 
-/*
- * Global keyboard-focus affordance. Per-component styles (buttons,
- * cards, inputs) override this where they have a more contextual
- * highlight; this is the catch-all so any `<a>`/`<button>` we forget
- * about still shows focus. `:focus-visible` only fires for keyboard
- * navigation — mouse clicks won't leave a stuck outline.
- */
+/* Catch-all keyboard focus. :focus-visible only fires for keyboard
+ * navigation; per-component styles override where contextual. */
 :focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -120,11 +85,8 @@ main {
   width: 100vw;
 }
 
-/*
- * Visually hidden until focused — keyboard users hitting Tab as the first
- * action get a "Skip to content" link they can activate to bypass the nav.
- * WCAG 2.4.1.
- */
+/* WCAG 2.4.1 skip-link — visually hidden off-canvas, slides into view
+ * on focus so keyboard users can bypass the nav. */
 .root__skip-link {
   position: absolute;
   top: -100px;
@@ -150,15 +112,8 @@ main {
   font-display: swap;
 }
 
-/*
- * Monaspace Neon — GitHub's experimental superfamily, mono variant.
- * Used as accent only: dates, tech chips, code-adjacent labels, the
- * "+N more" pill. Body text stays Roboto. Single weight (Regular,
- * ~200 KB WOFF2) is enough for these surfaces; if we ever need
- * weighted mono emphasis, swap to the variable file (~510 KB).
- *
- * License: SIL OFL. github.com/githubnext/monaspace
- */
+/* Monaspace Neon — accent face for dates, tech chips, code-adjacent
+ * labels. License: SIL OFL. github.com/githubnext/monaspace */
 @font-face {
   font-family: 'Monaspace Neon';
   src: url('/fonts/monaspace/MonaspaceNeon-Regular.woff2') format('woff2');
@@ -167,25 +122,16 @@ main {
   font-display: swap;
 }
 
-/*
- * Switch from bottom-stuck mobile nav to left-rail sidebar at the
- * tablet breakpoint ($bp-md = 768px) instead of the legacy
- * $desktop-small (1076px). Lifts the NavBar overlay off mid-page
- * content on iPad portrait + every Android tablet + narrow laptops.
- */
 @media screen and (min-width: $bp-md) {
   :root {
-    /* On desktop the rail is `position: fixed` and doesn't claim
-     * viewport vertical space — Home/etc. should fill the full 100vh
-     * without subtracting anything. */
+    /* Desktop rail is `position: fixed` — claims no vertical space. */
     --nav-h: 0px;
   }
 
   body {
-    /* Drop the mobile grid: NavBar uses `position: fixed` on
-     * desktop so it isn't part of normal flow. We just need a
-     * left-padding on the document content equal to the rail's
-     * width so the page text doesn't slide under it. */
+    /* Desktop: nav is fixed-positioned, out of flow. Body just needs a
+     * left-padding equal to the rail width so content doesn't slide
+     * under it. */
     display: block;
     height: auto;
     min-height: 100vh;


### PR DESCRIPTION
Drop ~300 lines of comments that restated tokens, narrated obvious declarations, or explained patterns already documented in CLAUDE.md. Kept comments where the *why* is non-obvious: library overrides (react-vertical-timeline-component), stylelint rule rationales, hand-picked banner crops on company logos, and cross-platform layout constraints (--nav-h, fixed-position desktop body).