### PR TITLE
fix(skills): move Date-dependent derivations into loader (CF prod fix)

### DIFF
--- a/app/routes/skills._index/index.tsx
+++ b/app/routes/skills._index/index.tsx
@@ -47,28 +47,36 @@ export const meta: MetaFunction = (args) =>
 const BLOCK = 'skills-route';
 const getClasses = getClassMaker(BLOCK);
 
-// Validated + derived once per worker boot. A malformed skills.json
-// throws a pretty-printed error pointing at the offending field.
+// Validated + derived once per worker boot for everything that's
+// time-independent. Anything that calls `new Date()` (heatmap year span,
+// "ongoing" job clamp, total-years figure) stays in the loader: on
+// Cloudflare Workers, `Date.now()` at module init returns 0 (Spectre
+// mitigation freezes Date until the first I/O event), so module-scope
+// derivations would lock the year-since to 1970 in production.
 const SKILLS = loadSkills(skillsJson);
-const HEATMAP_DATA = getSkillHeatmapData(SKILLS);
 const SUGGESTIONS = getSkillSuggestions(SKILLS);
-const TIMELINE_CARDS = [...SKILLS.WORK_ITEMS].reverse().map((item) => ({
+const TIMELINE_CARDS_BASE = [...SKILLS.WORK_ITEMS].reverse().map((item) => ({
   id: String(item.id),
   title: item.title,
-  date: formatDate(item.startDate, item.endDate ?? undefined),
-  texts: [item.rol],
-  textsLabel: 'ROLE',
+  startDate: item.startDate,
+  endDate: item.endDate ?? undefined,
+  rol: item.rol,
   skills: getSkillsForJob(SKILLS, item.id),
 }));
-const YEARS_OF_EXP = formatDate(SKILLS.WORK_ITEMS[0].startDate, undefined, 'fullYearMonth');
 
 export async function loader() {
+  const timelineCards = TIMELINE_CARDS_BASE.map(({ startDate, endDate, rol, ...rest }) => ({
+    ...rest,
+    date: formatDate(startDate, endDate),
+    texts: [rol],
+    textsLabel: 'ROLE',
+  }));
   return remixData(
     {
-      data: TIMELINE_CARDS,
-      yearsOfExp: YEARS_OF_EXP,
+      data: timelineCards,
+      yearsOfExp: formatDate(SKILLS.WORK_ITEMS[0].startDate, undefined, 'fullYearMonth'),
       skills: SUGGESTIONS,
-      heatmapData: HEATMAP_DATA,
+      heatmapData: getSkillHeatmapData(SKILLS),
       extraActivities: SKILLS.EXTRA_ACTIVITIES,
     },
     {

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -544,6 +544,19 @@
       ]
     },
     {
+      "title": "University",
+      "data": [
+        {
+          "title": "Technical Leader",
+          "text": "Technical Leader of the project for the career of Software Engineering. In charge of the development of the project and the team."
+        },
+        {
+          "title": "Career coaching",
+          "text": "Help students with their career path and guide them in their technical issues."
+        }
+      ]
+    },
+    {
       "title": "Qubika",
       "data": [
         {


### PR DESCRIPTION
Cloudflare Workers freeze Date at module-init (Spectre side-channel mitigation): new Date() / Date.now() returns 0 until the first I/O event. With getSkillHeatmapData(SKILLS) and the
formatDate(start, undefined, 'fullYearMonth') call hoisted to module scope, prod was rendering "-48 years -7 months" for the total-years card and a heatmap that stopped at 2023 (the latest authored endDate) because currentYear evaluated to 1970.

Move both calls — and the per-card date formatting, since the timeline list type was the natural carrier — into the loader. Keep loadSkills/getSkillSuggestions/getSkillsForJob at module scope (no Date dependency). Local Vite dev never reproduced this; only prod and wrangler pages dev exhibit the Date freeze.

Also restore the "University" entry in EXTRA_ACTIVITIES that was inadvertently dropped during the v1→v2 cutover.