### PR TITLE
fix(e2e): /skills heading assertion now matches "Skills" H2

### DIFF
--- a/tests/e2e/skills.spec.ts
+++ b/tests/e2e/skills.spec.ts
@@ -38,8 +38,8 @@ test.describe('Skills (/skills)', () => {
     ).toBeVisible();
   });
 
-  test('renders the Technologies section and tenure heatmap', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /Technologies/i })).toBeVisible();
+  test('renders the Skills section and tenure heatmap', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /^Skills$/ })).toBeVisible();
     // Heatmap container.
     await expect(page.locator('.tenure-heatmap').first()).toBeVisible();
     // The heatmap is derived from WORK_ITEMS — read its row-header


### PR DESCRIPTION
The skills section H2 was renamed Technologies → Skills in the Soft Skills group PR (#178), but the corresponding e2e assertion in skills.spec.ts wasn't updated, so CI's e2e job has been red on main since that merge.

Anchored the regex to ^Skills$ rather than /Skills/i because the page H1 ("Skills & Work Experience") also contains "Skills" and a loose match would resolve to both headings. Test name updated to reflect the new section title.