### PR TITLE
feat(cv): locale-aware DownloadBtn fileUrl on home route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,7 +283,7 @@ Adding a new field:
 
 Per-company logos live in `public/assets/img/<company-slug>.webp`. The `skills.$uuid` route resolves the image path by lowercasing `data.title`, with overrides for titles that don't directly map to a logo file (`Professor (part-time)` → `unsta2.webp`, `Teacher` → `coderhouse.webp`) — see `IMAGE_OVERRIDES` in the route.
 
-The CV PDF is at [public/assets/files/gonzalo_alvarez_campos_cv.pdf](public/assets/files/gonzalo_alvarez_campos_cv.pdf) and surfaced via [DownloadBtn](app/components/DownloadBtn/index.tsx).
+The English CV PDF is at [public/assets/files/gonzalo_alvarez_campos_cv.pdf](public/assets/files/gonzalo_alvarez_campos_cv.pdf) and surfaced via [DownloadBtn](app/components/DownloadBtn/index.tsx). The home route loader resolves a locale-specific URL via `getCvUrl(locale)` in [app/utils/utils.tsx](app/utils/utils.tsx) — when the Spanish PDF lands at `gonzalo_alvarez_campos_cv_es.pdf`, flip `HAS_ES_CV` to `true` in that helper and update [app/utils/utils.test.tsx](app/utils/utils.test.tsx) to assert the `_es` path. Until then, Spanish-locale visitors get the English PDF as a fallback rather than a 404.
 
 ---
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,8 +1,10 @@
-import type { MetaFunction } from '@remix-run/cloudflare';
+import { type LoaderFunctionArgs, type MetaFunction } from '@remix-run/cloudflare';
+import { useLoaderData } from '@remix-run/react';
 import { FormattedMessage } from 'react-intl';
 
 import DownloadButton from '~/components/DownloadBtn';
-import { getClassMaker, mergeRouteMeta } from '~/utils/utils';
+import { pickLocale } from '~/intl';
+import { getClassMaker, getCvUrl, mergeRouteMeta } from '~/utils/utils';
 
 import styles from './style.css?url';
 
@@ -11,6 +13,12 @@ import styles from './style.css?url';
 // is the documented shape for non-document, non-script asset prefetch
 // — the file is on the same origin (Cloudflare Pages) so anonymous
 // fetch matches the eventual <a href> request.
+//
+// `links()` runs without the request in scope, so we can't pick the
+// locale here. The English PDF is always available (it's the fallback
+// when a translation is missing) so prefetching it is the safe bet —
+// a Spanish visitor still gets the file warmed in cache; only the
+// hash differs.
 export const links = () => [
   { rel: 'stylesheet', href: styles },
   {
@@ -20,6 +28,10 @@ export const links = () => [
     crossOrigin: 'anonymous' as const,
   },
 ];
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  return { cvUrl: getCvUrl(pickLocale(request)) };
+}
 
 export const meta: MetaFunction = (args) =>
   mergeRouteMeta(args, {
@@ -32,6 +44,7 @@ const BLOCK = 'home-route';
 const getClasses = getClassMaker(BLOCK);
 
 export default function Index() {
+  const { cvUrl } = useLoaderData<typeof loader>();
   return (
     <div className={getClasses()}>
       <h1>
@@ -52,10 +65,7 @@ export default function Index() {
           </a>
         </span>
       </p>
-      <DownloadButton
-        fileUrl="/assets/files/gonzalo_alvarez_campos_cv.pdf"
-        fileName="Gonzalo_Alvarez_CV.pdf"
-      >
+      <DownloadButton fileUrl={cvUrl} fileName="Gonzalo_Alvarez_CV.pdf">
         <FormattedMessage id="DOWNLOAD_CV" />
       </DownloadButton>
     </div>

--- a/app/utils/utils.test.tsx
+++ b/app/utils/utils.test.tsx
@@ -5,6 +5,7 @@ import type { SkillsData } from '~/data/skills-schema';
 import {
   formatDate,
   getClassMaker,
+  getCvUrl,
   getSkillHeatmapData,
   getSkillsForJob,
   getSkillSuggestions,
@@ -261,6 +262,19 @@ describe('getSkillSuggestions', () => {
       ]
     );
     expect(getSkillSuggestions(data)).toEqual(['React', 'TypeScript']);
+  });
+});
+
+describe('getCvUrl', () => {
+  it('returns the English PDF for the en locale', () => {
+    expect(getCvUrl('en')).toBe('/assets/files/gonzalo_alvarez_campos_cv.pdf');
+  });
+
+  it('falls back to the English PDF for es while HAS_ES_CV is false', () => {
+    // When the Spanish PDF lands and HAS_ES_CV flips to true, this test
+    // should be flipped to assert the _es path. Until then the fallback
+    // is what keeps Spanish-locale visitors from hitting a 404.
+    expect(getCvUrl('es')).toBe('/assets/files/gonzalo_alvarez_campos_cv.pdf');
   });
 });
 

--- a/app/utils/utils.tsx
+++ b/app/utils/utils.tsx
@@ -3,6 +3,22 @@ import { differenceInMonths, format, formatDuration, intervalToDuration } from '
 import type { Skill, SkillsData, WorkItem } from '~/data/skills-schema';
 import type { Locale } from '~/intl';
 
+// Toggle this to `true` once a Spanish CV PDF lands at
+// public/assets/files/gonzalo_alvarez_campos_cv_es.pdf. Until then,
+// `getCvUrl('es')` falls back to the English file so a Spanish-locale
+// visitor still gets a working download instead of a 404.
+const HAS_ES_CV = false;
+
+const CV_URLS: Record<Locale, string> = {
+  en: '/assets/files/gonzalo_alvarez_campos_cv.pdf',
+  es: '/assets/files/gonzalo_alvarez_campos_cv_es.pdf',
+};
+
+export function getCvUrl(locale: Locale): string {
+  if (locale === 'es' && !HAS_ES_CV) return CV_URLS.en;
+  return CV_URLS[locale];
+}
+
 // Resolve a locale-specific string from a data-layer record.
 //
 // Convention: localizable fields (title, rol, description, project


### PR DESCRIPTION
Resolve the CV PDF URL via `getCvUrl(locale)` in the home loader so a Spanish-locale visitor can land at the Spanish PDF when it ships, without a code change at the call site. Until the Spanish file lands in `public/assets/files/`, the helper falls back to the English PDF (gated by the `HAS_ES_CV` flag in app/utils/utils.tsx).

The link prefetch in `links()` keeps pointing at the English PDF — `links()` runs without the request in scope, and the English file is the always-available fallback so prefetching it is safe regardless of locale.