### PR TITLE
fix(locale): persist locale across pages via cookie

### DIFF
--- a/app/components/LocaleToggle/index.test.tsx
+++ b/app/components/LocaleToggle/index.test.tsx
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { renderWithProviders, screen } from '~/../test/test-utils';
 
@@ -23,5 +24,36 @@ describe('LocaleToggle', () => {
       'aria-pressed',
       'false'
     );
+  });
+
+  describe('on click', () => {
+    beforeEach(() => {
+      // Reset cookie + storage between cases so assertions don't see leftovers.
+      document.cookie = 'locale=;Path=/;Max-Age=0';
+      localStorage.removeItem('locale');
+    });
+    afterEach(() => {
+      document.cookie = 'locale=;Path=/;Max-Age=0';
+      localStorage.removeItem('locale');
+    });
+
+    it('writes the locale cookie so the choice persists cross-page', () => {
+      renderWithProviders(<LocaleToggle current="en" />);
+      fireEvent.click(screen.getByRole('button', { name: /switch to es/i }));
+      expect(document.cookie).toMatch(/(?:^|; )locale=es(?:;|$)/);
+    });
+
+    it('also mirrors the choice into localStorage as a fallback channel', () => {
+      renderWithProviders(<LocaleToggle current="en" />);
+      fireEvent.click(screen.getByRole('button', { name: /switch to es/i }));
+      expect(localStorage.getItem('locale')).toBe('es');
+    });
+
+    it('is a no-op when clicking the already-active locale', () => {
+      renderWithProviders(<LocaleToggle current="es" />);
+      fireEvent.click(screen.getByRole('button', { name: /switch to es/i }));
+      expect(document.cookie).not.toMatch(/locale=/);
+      expect(localStorage.getItem('locale')).toBeNull();
+    });
   });
 });

--- a/app/components/LocaleToggle/index.tsx
+++ b/app/components/LocaleToggle/index.tsx
@@ -22,21 +22,23 @@ type Props = {
  * EN | ES pill that swaps the active site locale.
  *
  * Click flow:
- *   1. Persist the chosen locale to localStorage so it survives page
- *      reloads even when the user lands on a URL without `?lang=`.
- *   2. Push a navigation to the same path with `?lang=<next>`. The
- *      Remix root loader honours the search-param first via
- *      pickLocale, so the next render uses the new locale and
- *      `<html lang>` flips immediately. URL is shareable + crawlable.
- *   3. Mark the new active button with a transient `--popping`
+ *   1. Persist the chosen locale to a `locale` cookie (1-year expiry,
+ *      SameSite=Lax) so it survives page reloads AND ships on every
+ *      `<Link>` navigation — including Remix Single-Fetch `.data`
+ *      calls. That's what makes the choice cross-page: pickLocale
+ *      reads the cookie and resolves the same locale on every route.
+ *   2. Mirror the value into localStorage as a fallback channel for
+ *      the inline replay script (covers users who set the cookie on
+ *      a previous visit but cleared cookies, or pre-fix sessions
+ *      that only have the localStorage entry).
+ *   3. Push a navigation to the same path with `?lang=<next>`. The
+ *      URL search param is the highest-priority signal in pickLocale,
+ *      so the next render uses the new locale immediately. Keeps the
+ *      URL shareable + crawlable too — Google indexes each locale at
+ *      a distinct URL.
+ *   4. Mark the new active button with a transient `--popping`
  *      modifier so CSS plays a brief 1.0 → 1.08 → 1.0 scale on it —
  *      gives the click a tactile feedback beat without being noisy.
- *
- * No localStorage read here — the loader stays SSR-pure and only
- * looks at the URL and the request header. The user's saved choice
- * is replayed by the small `<script>` in app/root.tsx that, on first
- * paint, redirects to `?lang=<saved>` if localStorage holds a locale
- * different from the rendered one.
  */
 export default function LocaleToggle({ current }: Props) {
   const { formatMessage } = useIntl();
@@ -55,10 +57,18 @@ export default function LocaleToggle({ current }: Props) {
 
   function selectLocale(next: Locale) {
     if (next === current) return;
+    // 1-year expiry; Path=/ so it ships on every route. SameSite=Lax is
+    // the default but pinning it keeps the directive obvious to anyone
+    // auditing why the cookie shows up cross-origin (it doesn't).
+    // `document.cookie =` is the cookie-writing API even though it
+    // looks like a property mutation; the react-hooks immutability
+    // rule can't tell them apart, so opt out explicitly.
+    // eslint-disable-next-line react-hooks/immutability
+    document.cookie = `${STORAGE_KEY}=${next};Path=/;Max-Age=31536000;SameSite=Lax`;
     try {
       localStorage.setItem(STORAGE_KEY, next);
     } catch {
-      /* private mode / disabled storage — URL param still applies */
+      /* private mode / disabled storage — cookie + URL param still apply */
     }
     const nextParams = new URLSearchParams(searchParams);
     nextParams.set('lang', next);

--- a/app/intl/index.test.ts
+++ b/app/intl/index.test.ts
@@ -2,8 +2,17 @@ import { describe, expect, it } from 'vitest';
 
 import { pickLocale } from './index';
 
-function makeRequest(url: string, headers: Record<string, string> = {}) {
-  return new Request(url, { headers });
+// `cookie` is a forbidden header per the Fetch spec, so undici's
+// `new Request(...)` strips it from the init. We don't actually need
+// a real Request here — pickLocale only reads `request.url` and
+// `request.headers.get(name)`. A minimal shim covers both without
+// fighting the spec, and lets us exercise the cookie path.
+function makeRequest(url: string, headers: Record<string, string> = {}): Request {
+  const lower = Object.fromEntries(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  return {
+    url,
+    headers: { get: (name: string) => lower[name.toLowerCase()] ?? null },
+  } as unknown as Request;
 }
 
 describe('pickLocale', () => {
@@ -41,5 +50,28 @@ describe('pickLocale', () => {
 
   it('case-insensitive on the search param', () => {
     expect(pickLocale(makeRequest('https://example.com/?lang=ES'))).toBe('es');
+  });
+
+  it('reads the `locale` cookie when no `?lang=` is set', () => {
+    const req = makeRequest('https://example.com/skills', {
+      cookie: 'theme=dark; locale=es; other=foo',
+      'accept-language': 'en-US,en;q=0.9',
+    });
+    expect(pickLocale(req)).toBe('es');
+  });
+
+  it('prefers `?lang=` over the cookie', () => {
+    const req = makeRequest('https://example.com/?lang=en', {
+      cookie: 'locale=es',
+    });
+    expect(pickLocale(req)).toBe('en');
+  });
+
+  it('ignores an unsupported cookie value and falls through to Accept-Language', () => {
+    const req = makeRequest('https://example.com/', {
+      cookie: 'locale=fr',
+      'accept-language': 'es-AR,es;q=0.9',
+    });
+    expect(pickLocale(req)).toBe('es');
   });
 });

--- a/app/intl/index.ts
+++ b/app/intl/index.ts
@@ -11,17 +11,35 @@ const MESSAGES: Record<Locale, Record<string, string>> = {
 const SUPPORTED_LOCALES: Locale[] = ['en', 'es'];
 const DEFAULT_LOCALE: Locale = 'en';
 
+export const LOCALE_COOKIE = 'locale';
+
+function readCookie(request: Request, name: string): string | null {
+  const header = request.headers.get('cookie');
+  if (!header) return null;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) {
+      return decodeURIComponent(part.slice(eq + 1).trim());
+    }
+  }
+  return null;
+}
+
 /**
  * Pick the best supported locale for a request, in priority order:
  *   1. `?lang=` URL search param — explicit user override, also crawlable
  *      by search engines so each locale has a distinct indexable URL.
- *   2. `Accept-Language` request header — browser default for new visitors.
+ *   2. `locale` cookie — set by LocaleToggle on click. The cookie ships
+ *      on every request (full-page nav AND Single-Fetch `.data` calls),
+ *      so internal `<Link>` navigations preserve the chosen locale
+ *      without needing `?lang=` propagated through every URL.
+ *   3. `Accept-Language` request header — browser default for new visitors.
  *
- * The toggle component layers a localStorage-backed default on top of (1):
- * on click it sets `?lang=` AND localStorage; on subsequent renders the
- * client redirects to `?lang=` if localStorage holds a different locale.
- * That client-side redirect lives in the toggle, not here, so this stays
- * SSR-pure.
+ * The toggle also writes localStorage so a tiny <head> script can replay
+ * the saved choice into a cookie on the very first request from a
+ * pre-cookie session (visitors who picked Spanish before this fix
+ * shipped). Once the cookie lands, step (2) handles every subsequent nav.
  *
  * Spec note: we only honour the language part (`es-AR` → `es`), which is
  * fine for a 2-locale site. If we add regional variants later (`es-MX`
@@ -32,6 +50,11 @@ export function pickLocale(request: Request): Locale {
   const param = url.searchParams.get('lang')?.toLowerCase();
   if (param && SUPPORTED_LOCALES.includes(param as Locale)) {
     return param as Locale;
+  }
+
+  const cookie = readCookie(request, LOCALE_COOKIE)?.toLowerCase();
+  if (cookie && SUPPORTED_LOCALES.includes(cookie as Locale)) {
+    return cookie as Locale;
   }
 
   const header = request.headers.get('accept-language');

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -127,16 +127,21 @@ const PERSON_JSONLD = {
 // [data-theme='light'] selector swaps the palette tokens.
 const THEME_INIT_SCRIPT = `try{var t=localStorage.getItem('theme');if(t==='light'||t==='dark')document.documentElement.dataset.theme=t;else if(matchMedia('(prefers-color-scheme: light)').matches)document.documentElement.dataset.theme='light';}catch(e){}`;
 
-// Inline locale-replay script. Runs synchronously in <head>; if the
-// user has previously chosen a locale via LocaleToggle (persisted in
-// localStorage.locale) AND the current URL doesn't already pin that
-// locale via `?lang=`, redirect to the same URL with `?lang=<saved>`.
-// The redirect happens before paint so visitors never see a flash of
-// the Accept-Language-derived default before their saved choice
-// kicks in. The current `<html lang>` value identifies what the
-// loader resolved, used as the comparison anchor.
+// Inline locale-replay script. Runs synchronously in <head>; covers
+// the pre-cookie migration case where a user previously chose a locale
+// (persisted in localStorage.locale by older builds) but the cookie
+// channel hasn't been seeded yet. If localStorage holds a locale that
+// differs from what the loader resolved, write the cookie and redirect
+// to ?lang=<saved> so the next render picks it up. Once the cookie
+// lands, every subsequent request — including internal <Link> nav —
+// resolves the right locale server-side and this branch becomes a
+// no-op (the loader already matches localStorage).
+//
+// The current `<html lang>` value identifies what the loader resolved,
+// used as the comparison anchor. `?lang=` is the highest-priority
+// signal in pickLocale so the redirect always wins on first paint.
 function buildLocaleReplayScript(currentLocale: Locale) {
-  return `try{var s=localStorage.getItem('locale');if((s==='en'||s==='es')&&s!=='${currentLocale}'){var u=new URL(location.href);if(u.searchParams.get('lang')!==s){u.searchParams.set('lang',s);location.replace(u.toString());}}}catch(e){}`;
+  return `try{var s=localStorage.getItem('locale');if((s==='en'||s==='es')&&s!=='${currentLocale}'){document.cookie='locale='+s+';Path=/;Max-Age=31536000;SameSite=Lax';var u=new URL(location.href);if(u.searchParams.get('lang')!==s){u.searchParams.set('lang',s);location.replace(u.toString());}}}catch(e){}`;
 }
 
 // WebSite schema gives Google enough to surface a sitelinks search box

--- a/app/routes/skills._index/index.tsx
+++ b/app/routes/skills._index/index.tsx
@@ -95,12 +95,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
     {
       headers: {
         'Cache-Control': 'public, max-age=3600',
-        // Loader output now varies by locale (work-item rol/description,
+        // Loader output varies by locale (work-item rol/description,
         // extra-activity copy). Tell the edge to segment its cache key
-        // by `Accept-Language` so a Spanish-browser visitor doesn't get
-        // a cached English response and vice-versa. The `?lang=` URL
-        // param is already a different cache key on its own.
-        Vary: 'Accept-Language',
+        // by both `Accept-Language` (browser default for new visitors)
+        // AND `Cookie` — `pickLocale` reads the `locale` cookie set by
+        // LocaleToggle, so two visitors with the same Accept-Language
+        // but different cookie values must get different responses.
+        // The `?lang=` URL param is already a different cache key on
+        // its own.
+        Vary: 'Accept-Language, Cookie',
       },
     }
   );


### PR DESCRIPTION
The locale chosen via LocaleToggle was kept in `?lang=` + localStorage only. Internal `<Link>` navigations issue Single-Fetch `.data` requests that don't replay the head-script (it only runs on full document loads), so the saved locale was effectively dropped on every nav and the next page reverted to the Accept-Language default.

Fix: write a `locale` cookie alongside localStorage on toggle. Cookies ship on every request — full-page nav AND `.data` calls — so `pickLocale(request)` resolves the same locale on every route.

- pickLocale priority is now `?lang=` → cookie → Accept-Language. The search param still wins for shareable / crawlable URLs.
- LocaleToggle writes `locale=<next>;Path=/;Max-Age=31536000;SameSite=Lax` on click. localStorage stays as a fallback channel for the head-script migration path.
- Root replay script extended: when localStorage has a saved locale but the cookie hasn't been seeded yet (pre-fix sessions), it writes the cookie before the redirect. After one paint the cookie carries the choice from then on.
- /skills loader now sets `Vary: Accept-Language, Cookie` so the edge cache segments correctly between visitors with different locale cookies but identical Accept-Language headers.