### PR TITLE
feat(skills/:uuid): render skills as sorted pill chips

### DIFF
--- a/app/routes/skills.$uuid/index.tsx
+++ b/app/routes/skills.$uuid/index.tsx
@@ -101,7 +101,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       rol: localized(item, 'rol', locale),
       description: localized(item, 'description', locale),
       projects,
-      skills: getSkillsForJob(SKILLS, item.id),
+      skills: [...getSkillsForJob(SKILLS, item.id)].sort((a, b) => a.localeCompare(b)),
     },
     imagePath,
     imageDims,
@@ -177,7 +177,7 @@ export default function UuidIndex() {
       </div>
       {skills.length > 0 && (
         <div className={getClasses('skills')}>
-          <Card title={formatMessage({ id: 'SKILLS' })} texts={skills} />
+          <Card title={formatMessage({ id: 'SKILLS' })} skills={skills} showSkillsCta={false} />
         </div>
       )}
     </div>

--- a/app/routes/skills.$uuid/style.css
+++ b/app/routes/skills.$uuid/style.css
@@ -53,6 +53,15 @@
   }
 
   .card-component {
+    /* Detail-page skill chips: match the Carousel chips on /skills so
+     * the same visual primitive (pill, Monaspace, $space-4/$space-12
+     * padding, $border-6) reads consistently across both routes. The
+     * timeline preview chips on /skills keep Card's smaller default. */
+    &__chip {
+      padding: $space-4 $space-12;
+      border-radius: $border-6;
+    }
+
     &__main-text-wrapper {
       display: flex;
       gap: $space-20;


### PR DESCRIPTION
The Skills card on the work-item detail page was rendering each skill as a plain `<p>` line (Card's `texts` prop). Switch to `skills` + `showSkillsCta={false}` so it uses Card's chip-list pipeline — same visual primitive as the /skills page Carousel chips.

- Skills sort alphabetically (locale-aware compare) so the list reads the same on every job and matches the Carousel ordering pattern.
- Override the chip padding/radius locally to match Carousel ($space-4 $space-12, $border-6) so /skills and /skills/:uuid use the same chip shape. Card's smaller default still wins on the timeline preview chips on /skills.