### PR TITLE
refactor(carousel): render from skills.json via getAllSkillGroups

### DIFF
--- a/app/components/Carousel/index.stories.tsx
+++ b/app/components/Carousel/index.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import type { SkillGroup } from '~/utils/utils';
+
 import Carousel from './index';
 
 const meta: Meta<typeof Carousel> = {
@@ -11,4 +13,14 @@ export default meta;
 
 type Story = StoryObj<typeof Carousel>;
 
-export const Default: Story = {};
+const SAMPLE_GROUPS: SkillGroup[] = [
+  { id: 'TECH_GROUP_LANGUAGES', items: ['CSS', 'HTML', 'JavaScript', 'TypeScript'] },
+  { id: 'TECH_GROUP_FRAMEWORKS', items: ['Next.js', 'React', 'Remix', 'Vue'] },
+  { id: 'TECH_GROUP_TOOLING', items: ['Cypress', 'Git', 'Playwright', 'Storybook'] },
+  { id: 'TECH_GROUP_INFRA', items: ['Cloudflare', 'Heroku', 'MongoDB'] },
+  { id: 'TECH_GROUP_SOFT', items: ['Leadership', 'Mentoring', 'Teaching'] },
+];
+
+export const Default: Story = {
+  args: { groups: SAMPLE_GROUPS },
+};

--- a/app/components/Carousel/index.test.tsx
+++ b/app/components/Carousel/index.test.tsx
@@ -1,24 +1,39 @@
 import { describe, expect, it } from 'vitest';
 
 import { renderWithProviders } from '~/../test/test-utils';
+import type { SkillGroup } from '~/utils/utils';
 
 import Carousel from './index';
 
+const SAMPLE: SkillGroup[] = [
+  { id: 'TECH_GROUP_LANGUAGES', items: ['CSS', 'HTML', 'JavaScript', 'TypeScript'] },
+  { id: 'TECH_GROUP_FRAMEWORKS', items: ['React', 'Vue'] },
+  { id: 'TECH_GROUP_SOFT', items: ['Mentoring'] },
+];
+
 describe('Carousel', () => {
-  it('renders one chip per technology and one heading per category', () => {
-    const { container } = renderWithProviders(<Carousel />);
+  it('renders one chip per item and one heading per data group + the two forward-looking groups', () => {
+    const { container } = renderWithProviders(<Carousel groups={SAMPLE} />);
     const items = container.querySelectorAll('.carousel-component__item');
     const groups = container.querySelectorAll('.carousel-component__group-title');
-    expect(items.length).toBeGreaterThan(20);
-    // Languages, Frameworks, Tooling, Infrastructure, Soft skills, Learning, Future
-    expect(groups.length).toBe(7);
+    // 4 + 2 + 1 = 7 data chips, plus 2 learning + 1 future = 3 forward chips
+    expect(items.length).toBe(7 + 3);
+    // 3 data groups + Learning + Future = 5 group titles
+    expect(groups.length).toBe(5);
   });
 
   it('marks forward-looking groups (learning, future) with dashed-chip variant', () => {
-    const { container } = renderWithProviders(<Carousel />);
+    const { container } = renderWithProviders(<Carousel groups={SAMPLE} />);
     const learningChips = container.querySelectorAll('.carousel-component__item--learning');
     const futureChips = container.querySelectorAll('.carousel-component__item--future');
     expect(learningChips.length).toBeGreaterThan(0);
     expect(futureChips.length).toBeGreaterThan(0);
+  });
+
+  it('renders nothing in the data area when groups is empty (forward groups still render)', () => {
+    const { container } = renderWithProviders(<Carousel groups={[]} />);
+    const groups = container.querySelectorAll('.carousel-component__group-title');
+    // Only Learning + Future titles
+    expect(groups.length).toBe(2);
   });
 });

--- a/app/components/Carousel/index.tsx
+++ b/app/components/Carousel/index.tsx
@@ -1,5 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
+import type { SkillGroup } from '~/utils/utils';
 import { getClassMaker } from '~/utils/utils';
 
 // Carousel CSS is `@import`-inlined into the consuming route's style.css
@@ -8,59 +9,10 @@ import { getClassMaker } from '~/utils/utils';
 const BLOCK = 'carousel-component';
 const getClasses = getClassMaker(BLOCK);
 
-type Group = {
-  id: string;
-  // Modifier appended to the chip class so forward-looking groups
-  // (Learning, Future) render with dashed borders and a distinct
-  // accent label. Defaults to undefined → standard chip styling.
-  variant?: 'learning' | 'future';
-  // When true, `tech` holds intl message ids (translated per locale)
-  // instead of literal proper-noun strings. Tech-stack names like
-  // "TypeScript" stay literal in every language; soft skills like
-  // "Mentoring" / "Mentoría" want translation.
-  translate?: boolean;
-  tech: string[];
-};
-
-const CATEGORIES: Group[] = [
-  {
-    id: 'TECH_GROUP_LANGUAGES',
-    tech: ['TypeScript', 'JavaScript', 'Python', 'HTML', 'CSS', 'Sass'],
-  },
-  {
-    id: 'TECH_GROUP_FRAMEWORKS',
-    tech: ['React', 'Next.js', 'Remix', 'Vue', 'Node.js', 'Django', 'Express', 'GraphQL', 'Redux'],
-  },
-  {
-    id: 'TECH_GROUP_TOOLING',
-    tech: ['Storybook', 'Playwright', 'Cypress', 'Tailwind', 'Git', 'Axios'],
-  },
-  {
-    id: 'TECH_GROUP_INFRA',
-    tech: ['Cloudflare', 'Heroku', 'MongoDB', 'Highcharts', 'Agile'],
-  },
-  {
-    /* Soft skills extrapolated from the work history in skills.json:
-     * Mentoring (Endava intern program, Qubika senior internship,
-     * onboarding new colleagues), Leadership (Endava lead developer
-     * + technical consultant), Teaching (UNSTA Professor, Coderhouse
-     * web-programming Teacher), Code Review (named in two role write-
-     * ups), Team Coordination (MarkLogic project + internship orgs),
-     * Technical Interviewing (Qubika internship participant interviews),
-     * Public Speaking (lectures + classroom teaching). Translated per
-     * locale via the SOFT_SKILL_* intl keys. */
-    id: 'TECH_GROUP_SOFT',
-    translate: true,
-    tech: [
-      'SOFT_SKILL_MENTORING',
-      'SOFT_SKILL_LEADERSHIP',
-      'SOFT_SKILL_TEACHING',
-      'SOFT_SKILL_CODE_REVIEW',
-      'SOFT_SKILL_TEAM_COORDINATION',
-      'SOFT_SKILL_TECHNICAL_INTERVIEWING',
-      'SOFT_SKILL_PUBLIC_SPEAKING',
-    ],
-  },
+// Forward-looking groups stay hardcoded — they aren't job experiences
+// (no SKILLS entry, no range), they're aspirations / in-flight study.
+// Each entry is a literal chip string; not translated (proper nouns).
+const FORWARD_GROUPS: Array<{ id: string; variant: 'learning' | 'future'; tech: string[] }> = [
   {
     id: 'TECH_GROUP_LEARNING',
     variant: 'learning',
@@ -73,17 +25,31 @@ const CATEGORIES: Group[] = [
   },
 ];
 
-export default function Carousel() {
+type Props = {
+  groups: SkillGroup[];
+};
+
+export default function Carousel({ groups }: Props) {
   return (
     <div className={getClasses()}>
-      {CATEGORIES.map((group) => (
+      {groups.map((group) => (
+        <div key={group.id} className={getClasses('group')}>
+          <h3 className={getClasses('group-title')}>
+            <FormattedMessage id={group.id} />
+          </h3>
+          <ul className={getClasses('item-list')}>
+            {group.items.map((name) => (
+              <li key={name} className={getClasses('item')}>
+                {name}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+      {FORWARD_GROUPS.map((group) => (
         <div
           key={group.id}
-          className={
-            group.variant
-              ? `${getClasses('group')} ${getClasses('group', group.variant)}`
-              : getClasses('group')
-          }
+          className={`${getClasses('group')} ${getClasses('group', group.variant)}`}
         >
           <h3 className={getClasses('group-title')}>
             <FormattedMessage id={group.id} />
@@ -92,13 +58,9 @@ export default function Carousel() {
             {group.tech.map((name) => (
               <li
                 key={name}
-                className={
-                  group.variant
-                    ? `${getClasses('item')} ${getClasses('item', group.variant)}`
-                    : getClasses('item')
-                }
+                className={`${getClasses('item')} ${getClasses('item', group.variant)}`}
               >
-                {group.translate ? <FormattedMessage id={name} /> : name}
+                {name}
               </li>
             ))}
           </ul>

--- a/app/data/skills-schema.ts
+++ b/app/data/skills-schema.ts
@@ -22,6 +22,10 @@ const skillRange = z.object({
 
 const skill = z.object({
   name: z.string().min(1),
+  // Optional Spanish sibling. Resolved via `localized(skill, 'name', locale)`.
+  // Tech names (TypeScript, React, etc.) stay literal in both locales — only
+  // soft / meta skills like "Mentoring" → "Mentoría" need translation.
+  name_es: z.string().optional(),
   category: skillCategory,
   ranges: z.array(skillRange).min(1),
 });

--- a/app/routes/skills.$uuid/index.tsx
+++ b/app/routes/skills.$uuid/index.tsx
@@ -104,7 +104,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       rol: localized(item, 'rol', locale),
       description: localized(item, 'description', locale),
       projects,
-      skillGroups: getSkillGroupsForJob(SKILLS, item.id),
+      skillGroups: getSkillGroupsForJob(SKILLS, item.id, locale),
       startLabel,
       endLabel,
       duration,

--- a/app/routes/skills._index/index.tsx
+++ b/app/routes/skills._index/index.tsx
@@ -14,6 +14,7 @@ import { loadSkills } from '~/data/skills-schema';
 import { pickLocale } from '~/intl';
 import {
   formatDate,
+  getAllSkillGroups,
   getClassMaker,
   getSkillHeatmapData,
   getSkillsForJob,
@@ -90,6 +91,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       yearsOfExp: formatDate(SKILLS.WORK_ITEMS[0].startDate, undefined, 'fullYearMonth'),
       skills: SUGGESTIONS,
       heatmapData: getSkillHeatmapData(SKILLS),
+      carouselGroups: getAllSkillGroups(SKILLS, locale),
       extraActivities,
     },
     {
@@ -111,7 +113,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function Skills() {
   const { formatMessage } = useIntl();
-  const { data, yearsOfExp, skills, heatmapData, extraActivities } = useLoaderData<typeof loader>();
+  const { data, yearsOfExp, skills, heatmapData, carouselGroups, extraActivities } =
+    useLoaderData<typeof loader>();
   const [filteredData, setFilteredData] = useState(data);
 
   const filterInput = useCallback(
@@ -161,7 +164,7 @@ export default function Skills() {
             <LazyTenureHeatmap data={heatmapData} />
           </Suspense>
           <Suspense fallback={<LoadingSpinner />}>
-            <LazyCarousel />
+            <LazyCarousel groups={carouselGroups} />
           </Suspense>
         </div>
       </div>

--- a/app/utils/utils.test.tsx
+++ b/app/utils/utils.test.tsx
@@ -4,6 +4,7 @@ import type { SkillsData } from '~/data/skills-schema';
 
 import {
   formatDate,
+  getAllSkillGroups,
   getClassMaker,
   getCvUrl,
   getSkillGroupsForJob,
@@ -20,6 +21,7 @@ const fixture = (
   jobs: Array<{ id: number; startDate: string; endDate?: string }>,
   skills: Array<{
     name: string;
+    name_es?: string;
     category?: 'language' | 'framework' | 'tooling' | 'infra' | 'meta';
     ranges: Array<{ jobId: number; from?: string; to?: string }>;
   }>
@@ -33,6 +35,7 @@ const fixture = (
   })),
   SKILLS: skills.map((s) => ({
     name: s.name,
+    name_es: s.name_es,
     category: s.category ?? 'language',
     ranges: s.ranges,
   })),
@@ -307,6 +310,77 @@ describe('getSkillGroupsForJob', () => {
     );
     expect(getSkillGroupsForJob(data, 1)).toEqual([
       { id: 'TECH_GROUP_FRAMEWORKS', items: ['React'] },
+    ]);
+  });
+});
+
+describe('getSkillGroupsForJob (localized)', () => {
+  it('returns the English name when locale is en (or omitted)', () => {
+    const data = fixture(
+      [{ id: 1, startDate: '2020-01' }],
+      [{ name: 'Mentoring', name_es: 'Mentoría', category: 'meta', ranges: [{ jobId: 1 }] }]
+    );
+    expect(getSkillGroupsForJob(data, 1)).toEqual([
+      { id: 'TECH_GROUP_SOFT', items: ['Mentoring'] },
+    ]);
+    expect(getSkillGroupsForJob(data, 1, 'en')).toEqual([
+      { id: 'TECH_GROUP_SOFT', items: ['Mentoring'] },
+    ]);
+  });
+
+  it('returns the Spanish name when locale is es and name_es is present', () => {
+    const data = fixture(
+      [{ id: 1, startDate: '2020-01' }],
+      [{ name: 'Mentoring', name_es: 'Mentoría', category: 'meta', ranges: [{ jobId: 1 }] }]
+    );
+    expect(getSkillGroupsForJob(data, 1, 'es')).toEqual([
+      { id: 'TECH_GROUP_SOFT', items: ['Mentoría'] },
+    ]);
+  });
+
+  it('falls back to English when name_es is missing under locale=es', () => {
+    const data = fixture(
+      [{ id: 1, startDate: '2020-01' }],
+      [{ name: 'TypeScript', category: 'language', ranges: [{ jobId: 1 }] }]
+    );
+    expect(getSkillGroupsForJob(data, 1, 'es')).toEqual([
+      { id: 'TECH_GROUP_LANGUAGES', items: ['TypeScript'] },
+    ]);
+  });
+});
+
+describe('getAllSkillGroups', () => {
+  it('buckets every skill in the data regardless of job', () => {
+    const data = fixture(
+      [
+        { id: 1, startDate: '2020-01' },
+        { id: 2, startDate: '2021-01' },
+      ],
+      [
+        { name: 'TypeScript', category: 'language', ranges: [{ jobId: 1 }] },
+        { name: 'CSS', category: 'language', ranges: [{ jobId: 2 }] },
+        { name: 'React', category: 'framework', ranges: [{ jobId: 1 }, { jobId: 2 }] },
+        { name: 'Mentoring', name_es: 'Mentoría', category: 'meta', ranges: [{ jobId: 2 }] },
+      ]
+    );
+    expect(getAllSkillGroups(data)).toEqual([
+      { id: 'TECH_GROUP_LANGUAGES', items: ['CSS', 'TypeScript'] },
+      { id: 'TECH_GROUP_FRAMEWORKS', items: ['React'] },
+      { id: 'TECH_GROUP_SOFT', items: ['Mentoring'] },
+    ]);
+  });
+
+  it('localizes skill names when locale is es', () => {
+    const data = fixture(
+      [{ id: 1, startDate: '2020-01' }],
+      [
+        { name: 'TypeScript', category: 'language', ranges: [{ jobId: 1 }] },
+        { name: 'Mentoring', name_es: 'Mentoría', category: 'meta', ranges: [{ jobId: 1 }] },
+      ]
+    );
+    expect(getAllSkillGroups(data, 'es')).toEqual([
+      { id: 'TECH_GROUP_LANGUAGES', items: ['TypeScript'] },
+      { id: 'TECH_GROUP_SOFT', items: ['Mentoría'] },
     ]);
   });
 });

--- a/app/utils/utils.tsx
+++ b/app/utils/utils.tsx
@@ -345,18 +345,14 @@ const CATEGORY_GROUPS: Array<{ id: string; categories: SkillCategory[] }> = [
   { id: 'TECH_GROUP_SOFT', categories: ['meta'] },
 ];
 
-export function getSkillGroupsForJob(skillsData: SkillsData, jobId: number): SkillGroup[] {
-  const byName = new Map<string, SkillCategory>();
-  for (const s of skillsData.SKILLS) {
-    if (s.ranges.some((r) => r.jobId === jobId)) {
-      byName.set(s.name, s.category);
-    }
-  }
+function buildGroups(skills: Skill[], locale: Locale): SkillGroup[] {
   const groups: SkillGroup[] = [];
   for (const group of CATEGORY_GROUPS) {
     const items: string[] = [];
-    for (const [name, cat] of byName) {
-      if (group.categories.includes(cat)) items.push(name);
+    for (const s of skills) {
+      if (group.categories.includes(s.category)) {
+        items.push(localized(s, 'name', locale));
+      }
     }
     if (items.length > 0) {
       items.sort((a, b) => a.localeCompare(b));
@@ -364,6 +360,23 @@ export function getSkillGroupsForJob(skillsData: SkillsData, jobId: number): Ski
     }
   }
   return groups;
+}
+
+export function getSkillGroupsForJob(
+  skillsData: SkillsData,
+  jobId: number,
+  locale: Locale = 'en'
+): SkillGroup[] {
+  const skills = skillsData.SKILLS.filter((s) => s.ranges.some((r) => r.jobId === jobId));
+  return buildGroups(skills, locale);
+}
+
+// Every skill in the data layer, bucketed by category. Used by the
+// home Carousel to render the full tech-stack overview without
+// hardcoding the list in the component. Mirrors getSkillGroupsForJob
+// but doesn't filter by job — every entry in SKILLS contributes.
+export function getAllSkillGroups(skillsData: SkillsData, locale: Locale = 'en'): SkillGroup[] {
+  return buildGroups(skillsData.SKILLS, locale);
 }
 
 // Names of skills shown in the autocomplete on /skills. Excludes `meta`

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -159,7 +159,8 @@
         {
           "jobId": 6
         }
-      ]
+      ],
+      "name_es": "Metodologías ágiles"
     },
     {
       "name": "Axios",
@@ -187,7 +188,8 @@
         {
           "jobId": 4
         }
-      ]
+      ],
+      "name_es": "Back End"
     },
     {
       "name": "C",
@@ -205,6 +207,25 @@
         {
           "jobId": 6,
           "to": "2024-01"
+        }
+      ]
+    },
+    {
+      "name": "Code Review",
+      "name_es": "Revisión de código",
+      "category": "meta",
+      "ranges": [
+        {
+          "jobId": 1
+        },
+        {
+          "jobId": 2
+        },
+        {
+          "jobId": 4
+        },
+        {
+          "jobId": 6
         }
       ]
     },
@@ -267,6 +288,25 @@
         {
           "jobId": 6
         }
+      ],
+      "name_es": "Front End"
+    },
+    {
+      "name": "Git",
+      "category": "tooling",
+      "ranges": [
+        {
+          "jobId": 1
+        },
+        {
+          "jobId": 2
+        },
+        {
+          "jobId": 4
+        },
+        {
+          "jobId": 6
+        }
       ]
     },
     {
@@ -318,15 +358,6 @@
       ]
     },
     {
-      "name": "Interviewing",
-      "category": "meta",
-      "ranges": [
-        {
-          "jobId": 4
-        }
-      ]
-    },
-    {
       "name": "JavaScript",
       "category": "language",
       "ranges": [
@@ -363,7 +394,8 @@
         {
           "jobId": 4
         }
-      ]
+      ],
+      "name_es": "Liderazgo"
     },
     {
       "name": "MarkLogic",
@@ -380,6 +412,19 @@
       "ranges": [
         {
           "jobId": 3
+        }
+      ],
+      "name_es": "Mentoría"
+    },
+    {
+      "name": "MongoDB",
+      "category": "infra",
+      "ranges": [
+        {
+          "jobId": 1
+        },
+        {
+          "jobId": 2
         }
       ]
     },
@@ -429,6 +474,26 @@
         },
         {
           "jobId": 5
+        }
+      ],
+      "name_es": "Programación"
+    },
+    {
+      "name": "Public Speaking",
+      "name_es": "Oratoria",
+      "category": "meta",
+      "ranges": [
+        {
+          "jobId": 3
+        },
+        {
+          "jobId": 4
+        },
+        {
+          "jobId": 5
+        },
+        {
+          "jobId": 6
         }
       ]
     },
@@ -551,7 +616,31 @@
         {
           "jobId": 5
         }
+      ],
+      "name_es": "Docencia"
+    },
+    {
+      "name": "Team Coordination",
+      "name_es": "Coordinación de equipos",
+      "category": "meta",
+      "ranges": [
+        {
+          "jobId": 4
+        },
+        {
+          "jobId": 6
+        }
       ]
+    },
+    {
+      "name": "Technical Interviewing",
+      "category": "meta",
+      "ranges": [
+        {
+          "jobId": 4
+        }
+      ],
+      "name_es": "Entrevistas técnicas"
     },
     {
       "name": "TypeScript",


### PR DESCRIPTION
Carousel was hardcoding tech-stack arrays (Languages / Frameworks / Tooling / Infrastructure / Soft skills) that drifted from public/data/skills.json: a few items were on Carousel but missing from the schema (Git, MongoDB, Code Review, Team Coordination, Public Speaking), and a few were on both with wrong categories (GraphQL listed under Frameworks; Highcharts + Agile listed under Infrastructure).

This sync makes skills.json the single source of truth:

- New `getAllSkillGroups(data, locale)` helper in utils — the job-agnostic sibling of `getSkillGroupsForJob`. Both share the same `buildGroups` internals so categorization stays consistent.
- New optional `name_es` field on skill entries in the Zod schema, resolved via the existing `localized()` helper. Soft skills like "Mentoring" → "Mentoría" now translate everywhere (home Carousel, /skills/:uuid chip groups, etc.) instead of only on the home page.
- skills.json updates:
  - Added missing skills: Git (jobs 1/2/4/6), MongoDB (jobs 1/2), Code Review (jobs 1/2/4/6), Team Coordination (jobs 4/6), Public Speaking (jobs 3/4/5/6).
  - Renamed Interviewing → Technical Interviewing.
  - Added name_es siblings on Agile, Leadership, Mentoring, Programming, Teaching, plus the new soft skills.
  - Sorted SKILLS alphabetically by name for easier review.
- Carousel rewritten as a thin renderer that takes a `groups` prop; forward-looking groups (Currently learning, Coming up) stay hardcoded since they aren't job experiences.
- /skills loader now passes `carouselGroups: getAllSkillGroups(...)`.

Tests: +6 (locale resolution paths for both helpers, getAllSkillGroups bucketing/sort, Carousel empty-groups handling). Total 77 unit tests.