### PR TITLE
docs(drift): sync README + AGENTS to current state (C1/C2/C3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,8 @@ Guidelines for AI agents (Claude Code, Cursor, Aider, etc.) working in this repo
 Personal portfolio / online CV for **Gonzalo Alvarez Campos**, deployed at <https://gonzalo-alvarez-campos-cv.com/>.
 
 - Single-page-feel multi-route web app showcasing work history, skills, education, and a downloadable CV (PDF).
-- The frontend is the entire product today. The README mentions a future Python/Django backend and a contact form, but neither exists yet.
-- A future migration to React Router v7 or Next.js is on the table but not planned.
+- The frontend is the entire product today. Cloudflare Pages Functions handle SSR; there's no separate backend service. Future server-side concerns (e.g. a `/contact` form) would land as Pages Functions, not a standalone backend.
+- A future migration to React Router v7 is on the table (tracked as **T9** in [TECH-DEBT.md](TECH-DEBT.md)) but not actively planned.
 
 The site is content-driven: routes load static JSON files from [public/data/](public/data/) at request time and render them.
 
@@ -19,24 +19,24 @@ The site is content-driven: routes load static JSON files from [public/data/](pu
 
 ## 2. Stack
 
-| Layer             | Tech                                                                                         |
-| ----------------- | -------------------------------------------------------------------------------------------- |
-| Framework         | [Remix](https://remix.run/) v2.17 (Vite plugin), `cloudflare` adapter                        |
-| Build / dev       | Vite 5 + `@remix-run/dev` Vite plugin, Terser minification (sourcemaps off in prod)          |
-| Runtime / hosting | Cloudflare Pages (Pages Functions via `functions/[[path]].ts`)                               |
-| Wrangler          | v4 (`wrangler pages dev` / `wrangler pages deploy`)                                          |
-| UI                | React 18 + TypeScript                                                                        |
-| Routing           | Remix file-based / flat routes ([app/routes/](app/routes/))                                  |
-| Styling           | PostCSS (extend-rule, import, nested, simple-vars) + BEM via `getClassMaker`                 |
-| i18n              | `react-intl` (English + Spanish — picked from `Accept-Language`; see [app/intl/](app/intl/)) |
-| Charts            | CSS-grid tenure heatmap ([app/components/TenureHeatmap/](app/components/TenureHeatmap/))     |
-| Timeline          | `react-vertical-timeline-component`                                                          |
-| Dates             | `date-fns`                                                                                   |
-| Icons             | Local SVGs → SVGO → SVGR-generated React components                                          |
-| Linting           | ESLint 9 flat-config + Prettier, Stylelint, ls-lint                                          |
-| Type-check        | `tsc --noEmit` (Vite handles emit)                                                           |
-| Node              | `>=20.19.0` (`.nvmrc` pins `v20.19.5` — Storybook 10 floor)                                  |
-| npm               | `legacy-peer-deps=true` (set in `.npmrc`)                                                    |
+| Layer             | Tech                                                                                                         |
+| ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| Framework         | [Remix](https://remix.run/) v2.17 (Vite plugin), `cloudflare` adapter                                        |
+| Build / dev       | Vite 5 + `@remix-run/dev` Vite plugin, Terser minification (sourcemaps off in prod)                          |
+| Runtime / hosting | Cloudflare Pages (Pages Functions via `functions/[[path]].ts`)                                               |
+| Wrangler          | v4 (`wrangler pages dev` / `wrangler pages deploy`)                                                          |
+| UI                | React 18 + TypeScript                                                                                        |
+| Routing           | Remix file-based / flat routes ([app/routes/](app/routes/))                                                  |
+| Styling           | PostCSS (extend-rule, import, nested, simple-vars) + BEM via `getClassMaker`                                 |
+| i18n              | `react-intl` (English + Spanish; `?lang=` → `locale` cookie → `Accept-Language`; see [app/intl/](app/intl/)) |
+| Charts            | CSS-grid tenure heatmap ([app/components/TenureHeatmap/](app/components/TenureHeatmap/))                     |
+| Timeline          | `react-vertical-timeline-component`                                                                          |
+| Dates             | `date-fns`                                                                                                   |
+| Icons             | Local SVGs → SVGO → SVGR-generated React components                                                          |
+| Linting           | ESLint 9 flat-config + Prettier, Stylelint, ls-lint                                                          |
+| Type-check        | `tsc --noEmit` (Vite handles emit)                                                                           |
+| Node              | `>=20.19.0` (`.nvmrc` pins `v20.19.5` — Storybook 10 floor)                                                  |
+| npm               | `legacy-peer-deps=true` (set in `.npmrc`)                                                                    |
 
 **Tests:** Vitest + React Testing Library for components/utils, Playwright for E2E (chromium + Pixel 7 mobile project). See "Tests" section below.
 
@@ -73,7 +73,7 @@ remix-portfolio/
 │   │   └── icons/                # *** SVGR-generated, gitignored, do NOT edit ***
 │   ├── data/skills-schema.ts     # Zod schema + types + loadSkills() boot validator
 │   ├── assets/icons/             # Source .svg files (kebab-case)
-│   ├── intl/                     # en-US.json + es-ES.json + Accept-Language picker (index.ts)
+│   ├── intl/                     # en-US.json + es-ES.json + locale picker (index.ts)
 │   ├── styles/
 │   │   ├── constants.js          # Design tokens (colors, spacing, fonts, breakpoints)
 │   │   └── style.css             # Global body/html/main + @font-face Roboto + Monaspace
@@ -138,13 +138,13 @@ Remix flat-routes convention. All Remix v3 future flags are on (`v3_fetcherPersi
 
 **Single Fetch is on.** Loaders return raw objects (no `json()`). Use `data(payload, { headers, status })` from `@remix-run/cloudflare` only when you need to set response headers or a custom status; everything else is just `return { ... }`. The deprecated `json()` import will fail typecheck because `app/single-fetch.d.ts` augments `Future` to enable Single Fetch types.
 
-| URL                | File                                                                            | Loader                                                                                                                                                                                                                                |
-| ------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/`                | [app/routes/\_index.tsx](app/routes/_index.tsx)                                 | none                                                                                                                                                                                                                                  |
-| `/education`       | [app/routes/education.\_index/index.tsx](app/routes/education._index/index.tsx) | validates `education.json` via Zod once per worker boot (`loadEducation`); resolves `_es` siblings per request via `localized()`                                                                                                      |
-| `/education/:slug` | [app/routes/education.\$slug/index.tsx](app/routes/education.$slug/index.tsx)   | resolves `slug` to a degree key, localizes title/summary/description in the loader (so `<meta>` and render share copy); throws on miss → local `ErrorBoundary`                                                                        |
-| `/skills`          | [app/routes/skills.\_index/index.tsx](app/routes/skills._index/index.tsx)       | validates `skills.json` via Zod once per worker boot (`SKILLS`, `SUGGESTIONS` hoisted); the heatmap + total-years figure derive in the loader. Per-request: timeline cards + extras resolve `_es`. 1h cache + `Vary: Accept-Language` |
-| `/skills/:uuid`    | [app/routes/skills.\$uuid/index.tsx](app/routes/skills.$uuid/index.tsx)         | shares the same validated payload, finds `WORK_ITEMS[id == +uuid]`, derives skill chips via `getSkillsForJob`, throws on miss → renders local `ErrorBoundary`                                                                         |
+| URL                | File                                                                            | Loader                                                                                                                                                                                                                                        |
+| ------------------ | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/`                | [app/routes/\_index.tsx](app/routes/_index.tsx)                                 | none                                                                                                                                                                                                                                          |
+| `/education`       | [app/routes/education.\_index/index.tsx](app/routes/education._index/index.tsx) | validates `education.json` via Zod once per worker boot (`loadEducation`); resolves `_es` siblings per request via `localized()`                                                                                                              |
+| `/education/:slug` | [app/routes/education.\$slug/index.tsx](app/routes/education.$slug/index.tsx)   | resolves `slug` to a degree key, localizes title/summary/description in the loader (so `<meta>` and render share copy); throws on miss → local `ErrorBoundary`                                                                                |
+| `/skills`          | [app/routes/skills.\_index/index.tsx](app/routes/skills._index/index.tsx)       | validates `skills.json` via Zod once per worker boot (`SKILLS`, `SUGGESTIONS` hoisted); the heatmap + total-years figure derive in the loader. Per-request: timeline cards + extras resolve `_es`. 1h cache + `Vary: Accept-Language, Cookie` |
+| `/skills/:uuid`    | [app/routes/skills.\$uuid/index.tsx](app/routes/skills.$uuid/index.tsx)         | shares the same validated payload, finds `WORK_ITEMS[id == +uuid]`, derives skill chips via `getSkillsForJob`, throws on miss → renders local `ErrorBoundary`                                                                                 |
 
 There is no `/contact` route today — README mentions one as a future feature but the NavBar doesn't render any entry for it.
 
@@ -231,7 +231,7 @@ If a rule starts emitting false positives on a postcss-simple-vars expansion, pr
 
 ## 8. Internationalization
 
-`IntlProvider` wraps the app in [app/root.tsx](app/root.tsx) with the locale and messages chosen by the **root loader**: it calls `pickLocale(request)` from [app/intl/index.ts](app/intl/index.ts), which reads the `Accept-Language` header and returns `'en'` or `'es'` (falling back to English). Messages live next to that helper in [en-US.json](app/intl/en-US.json) and [es-ES.json](app/intl/es-ES.json).
+`IntlProvider` wraps the app in [app/root.tsx](app/root.tsx) with the locale and messages chosen by the **root loader**: it calls `pickLocale(request)` from [app/intl/index.ts](app/intl/index.ts), which resolves a locale in priority order — `?lang=` URL param → `locale` cookie (set by the NavBar `LocaleToggle`) → `Accept-Language` header → `'en'` default. Messages live next to that helper in [en-US.json](app/intl/en-US.json) and [es-ES.json](app/intl/es-ES.json).
 
 Use one of:
 
@@ -240,7 +240,7 @@ Use one of:
 
 Adding a key: append it to **both** `en-US.json` and `es-ES.json` — the registry is case-sensitive and will warn at runtime when a key is missing in one locale. Both files share the same `UPPER_SNAKE_CASE` shape; sort keys alphabetically by convention.
 
-Adding a third locale: extend `SUPPORTED_LOCALES` and the `MESSAGES` map in `app/intl/index.ts`, drop a sibling JSON next to the existing two. There is no UI switcher today — locale is browser-driven via `Accept-Language`.
+Adding a third locale: extend `SUPPORTED_LOCALES` and the `MESSAGES` map in `app/intl/index.ts`, drop a sibling JSON next to the existing two, and add a button to [app/components/LocaleToggle/index.tsx](app/components/LocaleToggle/index.tsx) (the toggle iterates over `SUPPORTED_LOCALES` so no math changes — just ensure the CSS knob's `--knob-index` math still works with the new column count).
 
 ---
 
@@ -257,7 +257,7 @@ To update content, edit those JSON files. Route loaders import them server-side 
 
 Both data files use **inline `_es` siblings** for localizable string fields. A field like `description` carries an optional `description_es` next to it; consumers resolve via [`localized(item, key, locale)`](app/utils/utils.tsx) in `app/utils/utils.tsx`. The helper falls back to the English field when the `_es` sibling is missing or empty, so partial translation is fine and never breaks a render. **Not** localized: company names, institution names, dates, ids, tech-stack chip text (proper nouns).
 
-Locale is resolved by [`pickLocale(request)`](app/intl/index.ts) in priority order: `?lang=` URL param → `Accept-Language` header → `'en'` default. Loaders that emit localized copy resolve it server-side and set `Vary: Accept-Language` on the response so the edge cache segments correctly.
+Locale is resolved by [`pickLocale(request)`](app/intl/index.ts) in priority order: `?lang=` URL param → `locale` cookie (set by `LocaleToggle` on click; 1-year expiry, `SameSite=Lax`) → `Accept-Language` header → `'en'` default. Loaders that emit localized copy resolve it server-side and set `Vary: Accept-Language, Cookie` on the response so the edge cache segments correctly across both signals.
 
 Adding a new field:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Remix Portfolio
 
-Welcome to my personal portfolio project! This is an ongoing project built with [Remix](https://remix.run/) and deployed on [Cloudflare Pages](https://pages.cloudflare.com/). The goal of this project is to showcase my skills, experience, and education in a visually appealing and interactive way. While the current focus is on the frontend, the backend will eventually be developed using Python and Django. Additionally, a contact form will be added in the future to make it easier for visitors to reach out.
+Welcome to my personal portfolio project! This is an ongoing project built with [Remix](https://remix.run/) and deployed on [Cloudflare Pages](https://pages.cloudflare.com/). The goal of this project is to showcase my skills, experience, and education in a visually appealing and interactive way. The site is bilingual (English + Spanish) with a visible locale toggle and a downloadable CV.
 
 The project has been deployed and is hosted in this url https://gonzalo-alvarez-campos-cv.com/
 
@@ -65,7 +65,7 @@ For the full agent-facing reference (architecture, conventions, gotchas), see [A
 What this project ships that goes beyond a "static CV page":
 
 - **Multi-route Remix app** with file-based flat routing — Home, Skills (with detail pages per work item), Education (with detail pages per degree), and a downloadable CV.
-- **Internationalization** via `react-intl` — English and Spanish, picked from the request's `Accept-Language` header at the root loader.
+- **Internationalization** via `react-intl` — English and Spanish, with a visible `EN | ES` toggle in the NavBar. The active locale is resolved server-side by `pickLocale(request)` in priority order: `?lang=` URL param → `locale` cookie (set by the toggle) → `Accept-Language` header. The cookie ships on every request so the chosen locale persists across page navigations.
 - **Single Fetch + lazy route discovery** — Remix v3 future flags enabled. Loaders return raw objects; the tenure heatmap, tech-grid, and timeline are JS-lazy-loaded so the initial `/skills` bundle stays small.
 - **Skill-first JSON schema with Zod validation** — `public/data/skills.json` follows a skill-first model: every skill is authored once with a list of date-bounded ranges that point at jobs by id. Validated at worker boot (a malformed file throws a path-precise error before any consumer reads it). The tenure heatmap, autocomplete suggestions, and per-job chip lists all derive from the same payload — no parallel data sources.
 - **Cloudflare Pages deployment** — Pages Functions handle SSR via Wrangler, with edge-cached static assets (`Cache-Control: public, max-age=31536000, immutable`) and a per-route 1h cache on the skills page.
@@ -108,13 +108,6 @@ Things I learned about working with an AI collaborator on a real project:
 
 ---
 
-## Future Plans
+## Roadmap
 
-This project is a work in progress, and here are some planned features and improvements:
-
-- **Backend development**: Python and Django for handling dynamic content + data persistence.
-- **Contact form**: easier outreach for visitors.
-- **Locale switcher UI**: today the locale is browser-driven (`Accept-Language`); a visible en/es toggle is on the backlog.
-- **Possible framework migration**: React Router v7 or Next.js are on the table but not actively planned.
-
-Stay tuned for updates as the project evolves!
+The active backlog lives in [TECH-DEBT.md](TECH-DEBT.md) — technical improvements, cleanup items, and UI/feature ideas, each with a priority and a status column.

--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -31,9 +31,9 @@
 | T13 | Technical | P3       | Drop unused `@chromatic-com/storybook`                         | open   |
 | T14 | Technical | P3       | Replace husky with simple-git-hooks                            | open   |
 | T15 | Technical | P3       | `import/no-relative-parent-imports` ESLint rule                | open   |
-| C1  | Cleanup   | P0       | Doc drift: README locale claims                                | open   |
-| C2  | Cleanup   | P0       | Doc drift: README "Future Plans" (Python/Django, contact form) | open   |
-| C3  | Cleanup   | P0       | Doc drift: AGENTS.md cross-refs to README plans                | open   |
+| C1  | Cleanup   | P0       | Doc drift: README locale claims                                | done   |
+| C2  | Cleanup   | P0       | Doc drift: README "Future Plans" (Python/Django, contact form) | done   |
+| C3  | Cleanup   | P0       | Doc drift: AGENTS.md cross-refs to README plans                | done   |
 | C4  | Cleanup   | P1       | Data: `Mentoring` ranges (Endava + Qubika missing)             | open   |
 | C5  | Cleanup   | P1       | Data: `Leadership` ranges (Qubika missing?)                    | open   |
 | C6  | Cleanup   | P2       | Rename ambiguous `Programming` meta skill                      | open   |


### PR DESCRIPTION
C1 — README locale claims:
- Intro paragraph dropped the "Python/Django backend, contact form someday" promise and now leads with the bilingual visible-toggle reality.
- Features bullet on i18n describes the actual priority chain (?lang= → cookie → Accept-Language) instead of the stale Accept-Language-only version.

C2 — README "Future Plans":
- Section deleted. The active backlog already lives in TECH-DEBT.md with priorities + status. Replaced with a one-line Roadmap pointer.

C3 — AGENTS.md cross-refs:
- §1 dropped the README cross-ref claiming Python/Django + contact form are coming. Clarified that Cloudflare Pages Functions are the backend.
- §2 stack table i18n row updated to the priority chain.
- §3 repo layout: intl/ comment no longer says "Accept-Language picker."
- §5 routing table: /skills row now correctly states `Vary: Accept-Language, Cookie` (the cookie was added in PR #193).
- §8 i18n section: pickLocale priority chain spelled out; "no UI switcher today" line replaced with the actual LocaleToggle setup
  + how to add a third locale.
- §9 data localization paragraph: priority chain + Vary header updated to include the cookie.

TECH-DEBT.md: marked C1/C2/C3 done.