### PR TITLE
chore(p0): close T3 + T4 + U5 small-win bundle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ Remix flat-routes convention. All Remix v3 future flags are on (`v3_fetcherPersi
 
 There is no `/contact` route today — README mentions one as a future feature but the NavBar doesn't render any entry for it.
 
-Loaders import the JSON directly from `public/data/` so Vite bakes it into the server bundle. The static asset is still served at `/data/*` for any external consumer via the `_routes.json` exclude.
+Loaders import the JSON directly from `public/data/` so Vite bakes it into the server bundle. The files are no longer served from `/data/*` — `_routes.json` routes that path to the Pages Function (which 404s), so the JSON is only readable through the rendered routes. This is intentional: the data is the CV content; we don't want scrapers lifting the entire payload (including draft Spanish translations) by hitting a public URL.
 
 ---
 

--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -18,8 +18,8 @@
 | --- | --------- | -------- | -------------------------------------------------------------- | ------ |
 | T1  | Technical | P0       | a11y test coverage in CI (axe-playwright)                      | open   |
 | T2  | Technical | P0       | Lighthouse gating in CI                                        | open   |
-| T3  | Technical | P0       | Stop serving `/data/*` publicly                                | open   |
-| T4  | Technical | P0       | `fetchpriority="high"` on company logo (`/skills/:uuid`)       | open   |
+| T3  | Technical | P0       | Stop serving `/data/*` publicly                                | done   |
+| T4  | Technical | P0       | `fetchpriority="high"` on company logo (`/skills/:uuid`)       | done   |
 | T5  | Technical | P1       | Recover `/skills` Lighthouse perf (0.87 → 0.95+)               | open   |
 | T6  | Technical | P1       | Bundle visualizer audit                                        | open   |
 | T7  | Technical | P1       | Move visual-baseline regen to CI workflow                      | open   |
@@ -47,7 +47,7 @@
 | U2  | UI        | P0       | Print stylesheet (CV page printable)                           | open   |
 | U3  | UI        | P0       | Promote in-progress Bachelor's on `/education`                 | open   |
 | U4  | UI        | P0       | Locale-aware date format on `/education` (match `:slug`)       | open   |
-| U5  | UI        | P0       | Match contrast fix on DownloadBtn hover state                  | open   |
+| U5  | UI        | P0       | Match contrast fix on DownloadBtn hover state                  | done   |
 | U6  | UI        | P1       | `/contact` route (CF Pages Function + Resend / Loops)          | open   |
 | U7  | UI        | P1       | Case studies — `/projects/<slug>` (3-5 deep-dives)             | open   |
 | U8  | UI        | P1       | Per-route OG images                                            | open   |

--- a/app/components/DownloadBtn/style.css
+++ b/app/components/DownloadBtn/style.css
@@ -20,10 +20,11 @@
   &:hover,
   &:focus-visible {
     background: var(--accent);
-    /* Hard white on the accent green for contrast on both themes —
-     * GitHub's hero-green is dark enough that white text reads
-     * cleanly. */
-    color: #ffffff;
+    /* Near-black on the green: `#ffffff` against `--accent` is only
+     * ~2.4:1 (below WCAG AA 4.5:1) — same finding Lighthouse flagged
+     * on LocaleToggle. `$gray-6` lands at ~6.5:1 and reads correctly
+     * in both themes since the hover background is theme-invariant. */
+    color: $gray-6;
     border-color: var(--accent);
     box-shadow: 0 4px 16px rgba(15, 191, 62, 0.2);
     text-decoration: none;

--- a/app/routes/skills.$uuid/index.tsx
+++ b/app/routes/skills.$uuid/index.tsx
@@ -172,6 +172,8 @@ export default function UuidIndex() {
             alt={title}
             width={imageDims.width}
             height={imageDims.height}
+            fetchPriority="high"
+            decoding="async"
             className={getClasses('company-logo')}
           />
         </div>

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -5,7 +5,6 @@
     "/favicon.ico",
     "/assets/*",
     "/fonts/*",
-    "/data/*",
     "/robots.txt",
     "/sitemap.xml",
     "/.well-known/*"


### PR DESCRIPTION
Three independent P0 items from the tracker:

- **T3 — stop serving /data/* publicly.** Removed `/data/*` from the `_routes.json` exclude list, so requests to /data/skills.json hit the Pages Function (which 404s) instead of the static handler. Route loaders already import the JSON via Vite, so this changes nothing internally. Removes the scraper surface for the full CV payload including draft Spanish copy. AGENTS.md §9 paragraph updated to reflect the new behavior.

- **T4 — fetchpriority="high" on company logo.** The /skills/:uuid logo is the LCP candidate. Added `fetchPriority="high"` and `decoding="async"` so the browser prioritises it during the critical path. React 18 renders the prop as camelCase in the SSR output; HTML attribute parsing is case-insensitive so browsers honor it.

- **U5 — DownloadBtn hover contrast.** Hover state was `#ffffff` text on `--accent` green (#0fbf3e) — ~2.4:1, below WCAG AA 4.5:1. Same finding Lighthouse flagged earlier on LocaleToggle. Swapped to `$gray-6` (#101411) which lands at ~6.5:1 against the same green, in both themes.

TECH-DEBT.md status flipped: T3, T4, U5 → done.