### PR TITLE
data(skills): expand Mentoring + Leadership ranges (C4 + C5)

### DIFF
--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -34,8 +34,8 @@
 | C1  | Cleanup   | P0       | Doc drift: README locale claims                                | done   |
 | C2  | Cleanup   | P0       | Doc drift: README "Future Plans" (Python/Django, contact form) | done   |
 | C3  | Cleanup   | P0       | Doc drift: AGENTS.md cross-refs to README plans                | done   |
-| C4  | Cleanup   | P1       | Data: `Mentoring` ranges (Endava + Qubika missing)             | open   |
-| C5  | Cleanup   | P1       | Data: `Leadership` ranges (Qubika missing?)                    | open   |
+| C4  | Cleanup   | P1       | Data: `Mentoring` ranges (Endava + Qubika missing)             | done   |
+| C5  | Cleanup   | P1       | Data: `Leadership` ranges (Qubika missing?)                    | done   |
 | C6  | Cleanup   | P2       | Rename ambiguous `Programming` meta skill                      | open   |
 | C7  | Cleanup   | P2       | Merge `getSkillsForJob` into `getSkillGroupsForJob`            | open   |
 | C8  | Cleanup   | P3       | Move `mergeRouteMeta` out of `utils.tsx`                       | open   |

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -393,6 +393,9 @@
       "ranges": [
         {
           "jobId": 4
+        },
+        {
+          "jobId": 6
         }
       ],
       "name_es": "Liderazgo"
@@ -412,6 +415,12 @@
       "ranges": [
         {
           "jobId": 3
+        },
+        {
+          "jobId": 4
+        },
+        {
+          "jobId": 6
         }
       ],
       "name_es": "Mentoría"


### PR DESCRIPTION
Two soft skills were under-tagged relative to what the data actually shows:

- **Mentoring** (C4) was on Professor (id 3) only. Endava (id 4) description explicitly says "organized and mentored the Endava Argentina Internship program." Qubika (id 6) EXTRA_ACTIVITIES lists "Senior Internship" + "Frontend Mentor." Added both jobIds.
- **Leadership** (C5) was on Endava (id 4) only. Qubika (id 6) is a senior IC role ("key contributor on multiple complex web applications across diverse technologies and clients") — senior scope qualifies even without an explicit lead title. Added jobId 6.

Effect: Mentoring + Leadership chips now surface on the relevant `/skills/:uuid` detail pages, and both skills carry more weight in the tenure heatmap.

TECH-DEBT.md status: C4 + C5 → done.