### PR TITLE
feat(404): root error boundary polish (U9)

### DIFF
--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -51,7 +51,7 @@
 | U6  | UI        | P1       | `/contact` route (CF Pages Function + Resend / Loops)          | open   |
 | U7  | UI        | P1       | Case studies — `/projects/<slug>` (3-5 deep-dives)             | open   |
 | U8  | UI        | P1       | Per-route OG images                                            | open   |
-| U9  | UI        | P1       | 404 page polish (match `/skills/:uuid` error UI)               | open   |
+| U9  | UI        | P1       | 404 page polish (match `/skills/:uuid` error UI)               | done   |
 | U10 | UI        | P1       | Spanish CV PDF (flip `HAS_ES_CV`)                              | open   |
 | U11 | UI        | P2       | `/blog` or `/notes` — engineering write-ups                    | open   |
 | U12 | UI        | P2       | Heatmap cell tooltips (hover detail)                           | open   |

--- a/app/intl/en-US.json
+++ b/app/intl/en-US.json
@@ -1,5 +1,6 @@
 {
   "BACK_TO_EDUCATION": "Back to Education",
+  "BACK_TO_HOME": "Back to Home",
   "BACK_TO_SKILLS": "Back to Skills",
   "CERTIFICATION": "Certification",
   "CERTIFICATIONS": "Certifications",
@@ -18,6 +19,10 @@
   "EDUCATION": "Education",
   "ERROR_EDUCATION_BODY": "We couldn't load this education entry. It may have been removed or the link is broken.",
   "ERROR_EDUCATION_TITLE": "This education entry isn't available",
+  "ERROR_GENERIC_BODY": "Something went wrong while loading this page. Try again in a moment, or head back home.",
+  "ERROR_GENERIC_TITLE": "Something went wrong",
+  "ERROR_NOT_FOUND_BODY": "We couldn't find that page. The link may be outdated or the URL might be mistyped.",
+  "ERROR_NOT_FOUND_TITLE": "Page not found",
   "ERROR_WORK_ITEM_BODY": "We couldn't load this work experience. It may have been removed or the link is broken.",
   "ERROR_WORK_ITEM_TITLE": "This work experience isn't available",
   "EXTRA_ACTIVITIES": "Extra Activities",

--- a/app/intl/es-ES.json
+++ b/app/intl/es-ES.json
@@ -1,5 +1,6 @@
 {
   "BACK_TO_EDUCATION": "Volver a Educación",
+  "BACK_TO_HOME": "Volver al inicio",
   "BACK_TO_SKILLS": "Volver a Skills",
   "CERTIFICATION": "Certificación",
   "CERTIFICATIONS": "Certificaciones",
@@ -18,6 +19,10 @@
   "EDUCATION": "Educación",
   "ERROR_EDUCATION_BODY": "No pudimos cargar esta entrada educativa. Es posible que haya sido removida o que el enlace sea inválido.",
   "ERROR_EDUCATION_TITLE": "Esta entrada educativa no está disponible",
+  "ERROR_GENERIC_BODY": "Algo salió mal al cargar esta página. Intenta de nuevo en un momento, o volvé al inicio.",
+  "ERROR_GENERIC_TITLE": "Algo salió mal",
+  "ERROR_NOT_FOUND_BODY": "No pudimos encontrar esa página. El enlace puede estar desactualizado o la URL mal escrita.",
+  "ERROR_NOT_FOUND_TITLE": "Página no encontrada",
   "ERROR_WORK_ITEM_BODY": "No pudimos cargar esta experiencia laboral. Es posible que haya sido removida o que el enlace sea inválido.",
   "ERROR_WORK_ITEM_TITLE": "Esta experiencia laboral no está disponible",
   "EXTRA_ACTIVITIES": "Actividades extra",

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -231,24 +231,31 @@ export default function App() {
 }
 
 export function ErrorBoundary() {
+  // Layout runs around this boundary, so the html/head/body shell is
+  // intact — we just render the error panel where <Outlet /> would.
+  // useRouteLoaderData lets us pick the user's locale even when the
+  // child route's loader is what threw (the root loader still ran).
+  // Falls back to English when the root itself failed.
   const error = useRouteError();
+  const data = useRouteLoaderData<LayoutData>('root');
+  const locale: Locale = data?.locale ?? 'en';
+  const m = messagesFor(locale);
 
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div className="error-boundary">
-        <p>Page under development.</p>
-      </div>
-    );
-  }
-  if (error instanceof Error) {
-    return (
-      <div>
-        <h1>Error</h1>
-        <p>{error.message}</p>
-        <p>The stack trace is:</p>
-        <pre>{error.stack}</pre>
-      </div>
-    );
-  }
-  return <h1>Unknown Error</h1>;
+  const isResponse = isRouteErrorResponse(error);
+  const status = isResponse ? error.status : 'Error';
+  const isNotFound = isResponse && error.status === 404;
+
+  const title = isNotFound ? m.ERROR_NOT_FOUND_TITLE : m.ERROR_GENERIC_TITLE;
+  const body = isNotFound ? m.ERROR_NOT_FOUND_BODY : m.ERROR_GENERIC_BODY;
+
+  return (
+    <div className="error-boundary">
+      <p className="error-boundary__code">{status}</p>
+      <h1 className="error-boundary__title">{title}</h1>
+      <p className="error-boundary__body">{body}</p>
+      <a className="error-boundary__action" href="/">
+        <span aria-hidden="true">←</span> {m.BACK_TO_HOME}
+      </a>
+    </div>
+  );
 }

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -1,0 +1,16 @@
+// Catch-all splat route. Without this, unknown URLs trigger Remix's
+// default 404 path which does NOT run the root loader — meaning
+// `pickLocale(request)` never fires and the ErrorBoundary falls back
+// to English regardless of `?lang=` / cookie / Accept-Language.
+//
+// The splat matches everything that no other route handles. Its
+// loader throws a 404 Response immediately, which surfaces in the
+// root ErrorBoundary with locale resolved correctly (the root's
+// loader already ran since this splat IS a matched route).
+export async function loader() {
+  throw new Response('Not Found', { status: 404 });
+}
+
+export default function Splat() {
+  return null;
+}

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -102,11 +102,67 @@ main {
   border-radius: $border-4;
 }
 
+/* Root-level error UI (404, generic errors). Mirrors the design of
+ * the route-level error boundaries on /skills/:uuid and
+ * /education/:slug: big Monaspace status code, headline, body, back
+ * link. Rendered without IntlProvider so strings are pre-resolved
+ * via messagesFor(locale) in the ErrorBoundary component. */
 .error-boundary {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
-  width: 100vw;
+  justify-content: center;
+  text-align: center;
+  gap: $space-16;
+  padding: $space-40 $space-20;
+  margin: 0 auto;
+  max-width: 600px;
+  min-height: calc(100vh - var(--nav-h));
+
+  &__code {
+    margin: 0;
+    font-family: 'Monaspace Neon', ui-monospace, 'SF Mono', monospace;
+    font-size: 5rem;
+    font-weight: $weight-700;
+    line-height: 1;
+    color: var(--accent);
+    letter-spacing: -0.02em;
+  }
+
+  &__title {
+    margin: 0;
+    font-size: $font-24;
+    font-weight: $weight-700;
+    color: var(--fg-base);
+    line-height: 1.3;
+  }
+
+  &__body {
+    margin: 0;
+    color: var(--fg-muted);
+    line-height: 1.5;
+    max-width: 480px;
+  }
+
+  &__action {
+    color: var(--accent);
+    text-decoration: none;
+    font-size: $font-14;
+    font-weight: $weight-700;
+    padding: $space-8 $space-16;
+    border: 1px solid var(--accent);
+    border-radius: $border-6;
+    transition:
+      color 120ms ease,
+      background 120ms ease;
+
+    &:hover,
+    &:focus-visible {
+      color: var(--fg-on-accent);
+      background: var(--accent);
+      outline: none;
+    }
+  }
 }
 
 /* WCAG 2.4.1 skip-link — visually hidden off-canvas, slides into view

--- a/tests/e2e/error.spec.ts
+++ b/tests/e2e/error.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Root error boundary', () => {
+  test('renders a 404 panel for an unknown URL', async ({ page }) => {
+    // Hit a path that's definitively not a route. Use waitUntil:
+    // 'domcontentloaded' because Remix surfaces the error response
+    // immediately and we don't need to wait for any further loads.
+    const response = await page.goto('/this-route-does-not-exist', {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(response?.status()).toBe(404);
+
+    await expect(page.getByText('404', { exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /page not found/i, level: 1 })).toBeVisible();
+    await expect(page.getByRole('link', { name: /back to home/i })).toHaveAttribute('href', '/');
+  });
+
+  test('localizes the 404 panel under es', async ({ page }) => {
+    const response = await page.goto('/this-route-does-not-exist?lang=es', {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(response?.status()).toBe(404);
+
+    await expect(
+      page.getByRole('heading', { name: /página no encontrada/i, level: 1 })
+    ).toBeVisible();
+    await expect(page.getByRole('link', { name: /volver al inicio/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes U9. Brings the root error UI in line with the route-level boundaries on /skills/:uuid and /education/:slug — same primitives, same design language.

Before: 404 rendered "Page under development." Generic errors dumped raw `message + stack` to the user. Unknown errors rendered a bare "Unknown Error" h1.

After: centered panel with a big Monaspace status code, a localized headline (404 → "Page not found" / "Página no encontrada"; other → "Something went wrong" / "Algo salió mal"), a body line, and a "Back to Home" action button. Same design as the route-level error panels — visual consistency across all error surfaces.

Implementation notes:

- ErrorBoundary lives outside the IntlProvider (which mounts inside App() around <Outlet />), so strings resolve via `messagesFor(locale)` direct lookup — same pattern Layout already uses for SKIP_TO_CONTENT.
- Locale comes from `useRouteLoaderData<LayoutData>('root')`; falls back to 'en' if the root loader itself failed.
- Back link is a plain <a href="/"> not <Link> — at root-level error the Router context may not be available.

Catch-all splat route at `app/routes/$.tsx`. Without it, unknown URLs trigger Remix's default 404 path which DOES NOT run the root loader, so `pickLocale(request)` never fires and the boundary falls back to English regardless of ?lang=. The splat matches everything no other route handles and throws a 404 Response in its loader — by then root's loader has already run, so locale resolves correctly.

5 new intl keys per locale: BACK_TO_HOME, ERROR_NOT_FOUND_TITLE, ERROR_NOT_FOUND_BODY, ERROR_GENERIC_TITLE, ERROR_GENERIC_BODY.

E2E: new error.spec.ts with 2 specs covering 404 status code + EN heading + back link, and the ES-locale equivalent.

TECH-DEBT.md status: U9 → done.