### PR TITLE
refactor(skills): rename Programming → Teaching Programming, merge he…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ remix-portfolio/
 │   │   ├── constants.js          # Design tokens (colors, spacing, fonts, breakpoints)
 │   │   └── style.css             # Global body/html/main + @font-face Roboto + Monaspace
 │   └── utils/
-│       ├── utils.tsx              # getClassMaker, formatDate, getSkillHeatmapData, getSkillsForJob, getSkillSuggestions, localized, getCvUrl
+│       ├── utils.tsx              # getClassMaker, formatDate, getSkillHeatmapData, getSkillGroupsForJob, getAllSkillGroups, getSkillSuggestions, localized, getCvUrl
 │       └── meta.ts                # mergeRouteMeta (per-route title + OG/Twitter merger)
 ├── functions/[[path]].ts         # Cloudflare Pages Function — serves the Remix server build
 ├── public/
@@ -146,7 +146,7 @@ Remix flat-routes convention. All Remix v3 future flags are on (`v3_fetcherPersi
 | `/education`       | [app/routes/education.\_index/index.tsx](app/routes/education._index/index.tsx) | validates `education.json` via Zod once per worker boot (`loadEducation`); resolves `_es` siblings per request via `localized()`                                                                                                              |
 | `/education/:slug` | [app/routes/education.\$slug/index.tsx](app/routes/education.$slug/index.tsx)   | resolves `slug` to a degree key, localizes title/summary/description in the loader (so `<meta>` and render share copy); throws on miss → local `ErrorBoundary`                                                                                |
 | `/skills`          | [app/routes/skills.\_index/index.tsx](app/routes/skills._index/index.tsx)       | validates `skills.json` via Zod once per worker boot (`SKILLS`, `SUGGESTIONS` hoisted); the heatmap + total-years figure derive in the loader. Per-request: timeline cards + extras resolve `_es`. 1h cache + `Vary: Accept-Language, Cookie` |
-| `/skills/:uuid`    | [app/routes/skills.\$uuid/index.tsx](app/routes/skills.$uuid/index.tsx)         | shares the same validated payload, finds `WORK_ITEMS[id == +uuid]`, derives skill chips via `getSkillsForJob`, throws on miss → renders local `ErrorBoundary`                                                                                 |
+| `/skills/:uuid`    | [app/routes/skills.\$uuid/index.tsx](app/routes/skills.$uuid/index.tsx)         | shares the same validated payload, finds `WORK_ITEMS[id == +uuid]`, derives bucketed skill chips via `getSkillGroupsForJob`, throws on miss → renders local `ErrorBoundary`                                                                   |
 
 There is no `/contact` route today — README mentions one as a future feature but the NavBar doesn't render any entry for it.
 
@@ -281,7 +281,7 @@ Adding a new field:
 
 **Adding a job:** push a new `WORK_ITEMS` entry with the next `id`, then go through every relevant `SKILLS[].ranges` and add `{ jobId: <new-id> }` to the ones that apply at this job.
 
-**Heatmap, chart, autocomplete:** all derive from `SKILLS` via helpers in [app/utils/utils.tsx](app/utils/utils.tsx) — `getSkillHeatmapData`, `getSkillsForJob`, `getSkillSuggestions`. Computed once per worker boot and reused across requests.
+**Heatmap, chart, autocomplete:** all derive from `SKILLS` via helpers in [app/utils/utils.tsx](app/utils/utils.tsx) — `getSkillHeatmapData`, `getSkillGroupsForJob`, `getSkillSuggestions`. Computed once per worker boot and reused across requests.
 
 Per-company logos live in `public/assets/img/<company-slug>.webp`. The `skills.$uuid` route resolves the image path by lowercasing `data.title`, with overrides for titles that don't directly map to a logo file (`Professor (part-time)` → `unsta2.webp`, `Teacher` → `coderhouse.webp`) — see `IMAGE_OVERRIDES` in the route.
 

--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -37,8 +37,8 @@
 | C3  | Cleanup   | P0       | Doc drift: AGENTS.md cross-refs to README plans                | done   |
 | C4  | Cleanup   | P1       | Data: `Mentoring` ranges (Endava + Qubika missing)             | done   |
 | C5  | Cleanup   | P1       | Data: `Leadership` ranges (Qubika missing?)                    | done   |
-| C6  | Cleanup   | P2       | Rename ambiguous `Programming` meta skill                      | open   |
-| C7  | Cleanup   | P2       | Merge `getSkillsForJob` into `getSkillGroupsForJob`            | open   |
+| C6  | Cleanup   | P2       | Rename ambiguous `Programming` meta skill                      | done   |
+| C7  | Cleanup   | P2       | Merge `getSkillsForJob` into `getSkillGroupsForJob`            | done   |
 | C8  | Cleanup   | P3       | Move `mergeRouteMeta` out of `utils.tsx`                       | done   |
 | C9  | Cleanup   | P3       | Move `FORWARD_GROUPS` out of TechTree component                | done   |
 | C10 | Cleanup   | P3       | Validate `name_es` typos against a locale registry             | open   |
@@ -221,13 +221,13 @@ Currently `[{ jobId: 3 }]` (Professor only). Description text shows mentoring at
 
 Currently `[{ jobId: 4 }]` (Endava only). Qubika (id 6) senior-track work likely includes leadership moments. User to confirm.
 
-### C6 — Rename ambiguous `Programming` meta skill (P2)
+### C6 — Rename ambiguous `Programming` meta skill (P2) — DONE
 
-Tagged on Professor (id 3) + Teacher (id 5). The category is `meta` so it's a soft skill. Renaming to "Programming Education" or "Teaching Programming" disambiguates from the literal act of writing code.
+Renamed to "Teaching Programming" (`Enseñanza de Programación`) in [public/data/skills.json](public/data/skills.json). The meta-skill is tagged on Professor + Teacher roles; the verb-first form reads naturally next to the existing "Teaching" chip and disambiguates from the literal act of writing code.
 
-### C7 — Merge `getSkillsForJob` into `getSkillGroupsForJob` (P2)
+### C7 — Merge `getSkillsForJob` into `getSkillGroupsForJob` (P2) — DONE
 
-Group helper is a strict superset. Flat-list helper is only used by `/skills` index timeline-card chip strings. Could expose both shapes from one helper, or deprecate the flat one in favor of `getSkillGroupsForJob(...).flatMap(g => g.items)`. Reduces surface area.
+Dropped `getSkillsForJob` from [app/utils/utils.tsx](app/utils/utils.tsx); its single consumer (`/skills` index timeline cards) now calls `getSkillGroupsForJob(SKILLS, item.id, locale).flatMap((g) => g.items)`. Side effects: timeline-card chips are now (a) locale-aware (previously always English for meta skills) and (b) deterministically ordered (`language → framework → tooling → infra → meta`, alphabetical within each) instead of SKILLS-array order. Test suite trimmed accordingly.
 
 ### C8 — Move `mergeRouteMeta` out of `utils.tsx` (P3) — DONE
 

--- a/app/routes/skills._index/index.tsx
+++ b/app/routes/skills._index/index.tsx
@@ -17,8 +17,8 @@ import {
   formatDate,
   getAllSkillGroups,
   getClassMaker,
+  getSkillGroupsForJob,
   getSkillHeatmapData,
-  getSkillsForJob,
   getSkillSuggestions,
   localized,
 } from '~/utils/utils';
@@ -77,7 +77,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     date: formatDate(item.startDate, item.endDate ?? undefined),
     texts: [localized(item, 'rol', locale)],
     textsLabel: 'ROLE',
-    skills: getSkillsForJob(SKILLS, item.id),
+    skills: getSkillGroupsForJob(SKILLS, item.id, locale).flatMap((g) => g.items),
   }));
   const extraActivities = SKILLS.EXTRA_ACTIVITIES.map((activity) => ({
     title: activity.title,

--- a/app/utils/utils.test.tsx
+++ b/app/utils/utils.test.tsx
@@ -9,7 +9,6 @@ import {
   getCvUrl,
   getSkillGroupsForJob,
   getSkillHeatmapData,
-  getSkillsForJob,
   getSkillSuggestions,
   localized,
 } from './utils';
@@ -233,35 +232,6 @@ describe('getSkillHeatmapData', () => {
     );
     const react = getSkillHeatmapData(data).rows.find((r) => r.skill === 'React');
     expect(react?.monthsPerYear).toEqual([6]); // clipped to job's 6-month span
-  });
-});
-
-describe('getSkillsForJob', () => {
-  it('lists every skill with at least one range pointing at the jobId', () => {
-    const data = fixture(
-      [
-        { id: 1, startDate: '2020-01', endDate: '2021-01' },
-        { id: 2, startDate: '2021-01' },
-      ],
-      [
-        { name: 'React', ranges: [{ jobId: 1 }, { jobId: 2 }] },
-        { name: 'Vue', ranges: [{ jobId: 1 }] },
-        { name: 'Next.js', ranges: [{ jobId: 2 }] },
-      ]
-    );
-    expect(getSkillsForJob(data, 1)).toEqual(['React', 'Vue']);
-    expect(getSkillsForJob(data, 2)).toEqual(['React', 'Next.js']);
-  });
-
-  it('preserves authored order in SKILLS', () => {
-    const data = fixture(
-      [{ id: 1, startDate: '2020-01' }],
-      [
-        { name: 'Zod', ranges: [{ jobId: 1 }] },
-        { name: 'Apollo', ranges: [{ jobId: 1 }] },
-      ]
-    );
-    expect(getSkillsForJob(data, 1)).toEqual(['Zod', 'Apollo']);
   });
 });
 

--- a/app/utils/utils.tsx
+++ b/app/utils/utils.tsx
@@ -283,23 +283,14 @@ export function getSkillHeatmapData(skillsData: SkillsData): SkillHeatmapData {
   return { years, rows };
 }
 
-// Skills attached to a single job, ordered as authored in SKILLS.
-// Replaces the per-job `skills: SkillEntry[]` array that v1 carried on
-// each WORK_ITEM. Used by the timeline cards on /skills and the chip
-// list on /skills/:uuid.
-export function getSkillsForJob(skillsData: SkillsData, jobId: number): string[] {
-  const result: string[] = [];
-  for (const s of skillsData.SKILLS) {
-    if (s.ranges.some((r) => r.jobId === jobId)) {
-      result.push(s.name);
-    }
-  }
-  return result;
-}
-
-// Same set of skills as `getSkillsForJob`, bucketed by category for
-// the /skills/:uuid Skills card. Empty buckets are dropped. The `id`
-// on each group is the intl message id for the heading.
+// Skills attached to a single job, bucketed by category. The `id` on
+// each group is the intl message id for the heading rendered above
+// the chip list. Empty buckets are dropped.
+//
+// Consumers that just need a flat chip list (e.g. timeline cards on
+// /skills) call this and flatMap the items — the bucket order
+// (language → framework → tooling → infra → meta) gives them
+// deterministic, category-grouped ordering for free.
 export type SkillGroup = { id: string; items: string[] };
 
 const CATEGORY_GROUPS: Array<{ id: string; categories: SkillCategory[] }> = [

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -475,7 +475,7 @@
       ]
     },
     {
-      "name": "Programming",
+      "name": "Teaching Programming",
       "category": "meta",
       "ranges": [
         {
@@ -485,7 +485,7 @@
           "jobId": 5
         }
       ],
-      "name_es": "Programación"
+      "name_es": "Enseñanza de Programación"
     },
     {
       "name": "Public Speaking",


### PR DESCRIPTION
…lpers (C6, C7)

- **C6**: Renamed the ambiguous `Programming` meta skill to `Teaching Programming` (`Enseñanza de Programación`). The chip is tagged on Professor + Teacher jobs only — the verb-first form reads naturally next to the existing `Teaching` chip and disambiguates from the literal act of writing code.
- **C7**: Dropped `getSkillsForJob`; its single consumer (the `/skills` index timeline cards) now uses `getSkillGroupsForJob(SKILLS, item.id, locale).flatMap((g) => g.items)`. Side effects: timeline-card chips become (a) locale-aware (previously always English for meta skills) and (b) deterministically ordered (language → framework → tooling → infra → meta, alphabetical within each) instead of SKILLS-array order. Tests trimmed accordingly.

Also fixed an AGENTS.md stale reference — the `/skills/:uuid` row was documented to use `getSkillsForJob` but the route already calls `getSkillGroupsForJob`.