### PR TITLE
style(routes): standardise page-title across /skills, /projects, /edu…

### DIFF
--- a/app/intl/en-US.json
+++ b/app/intl/en-US.json
@@ -47,6 +47,7 @@
   "LOCALE_TOGGLE_LABEL": "Language",
   "LOCALE_TOGGLE_SWITCH_TO": "Switch to {locale}",
   "NO_MATCHES_FOUND": "No matches found",
+  "PAGE_TITLE_EDUCATION": "Education & Certifications",
   "PAGE_TITLE_PROJECTS": "Case Studies",
   "PAGE_TITLE_SKILLS": "Skills & Work Experience",
   "PRESENT": "Present",

--- a/app/intl/es-ES.json
+++ b/app/intl/es-ES.json
@@ -47,6 +47,7 @@
   "LOCALE_TOGGLE_LABEL": "Idioma",
   "LOCALE_TOGGLE_SWITCH_TO": "Cambiar a {locale}",
   "NO_MATCHES_FOUND": "Sin resultados",
+  "PAGE_TITLE_EDUCATION": "Educación y certificaciones",
   "PAGE_TITLE_PROJECTS": "Casos de estudio",
   "PAGE_TITLE_SKILLS": "Habilidades y experiencia laboral",
   "PRESENT": "Presente",

--- a/app/routes/education._index/index.tsx
+++ b/app/routes/education._index/index.tsx
@@ -112,6 +112,9 @@ export default function Skills() {
 
   return (
     <div className={getClasses()}>
+      <h1 className="route-page-title">
+        <FormattedMessage id="PAGE_TITLE_EDUCATION" />
+      </h1>
       <div className={getClasses('degree')}>
         <h2>
           <FormattedMessage id="DEGREES" />

--- a/app/routes/projects._index/index.tsx
+++ b/app/routes/projects._index/index.tsx
@@ -44,7 +44,7 @@ export default function ProjectsIndex() {
 
   return (
     <div className={getClasses()}>
-      <h1 className={getClasses('page-title')}>
+      <h1 className="route-page-title">
         <FormattedMessage id="PAGE_TITLE_PROJECTS" />
       </h1>
       <p className={getClasses('intro')}>

--- a/app/routes/projects._index/style.css
+++ b/app/routes/projects._index/style.css
@@ -7,11 +7,6 @@
   gap: $space-20;
   width: 100%;
 
-  &__page-title {
-    text-align: center;
-    margin: 0;
-  }
-
   &__intro {
     max-width: 65ch;
     text-align: center;

--- a/app/routes/skills._index/index.tsx
+++ b/app/routes/skills._index/index.tsx
@@ -134,7 +134,7 @@ export default function Skills() {
 
   return (
     <div className={getClasses()}>
-      <h1 className={getClasses('page-title')}>
+      <h1 className="route-page-title">
         <FormattedMessage id="PAGE_TITLE_SKILLS" />
       </h1>
       <div className={getClasses('time-line')}>

--- a/app/routes/skills._index/style.css
+++ b/app/routes/skills._index/style.css
@@ -19,12 +19,6 @@
   flex-direction: column;
   gap: $space-32;
 
-  &__page-title {
-    text-align: center;
-    font-size: $font-30;
-    margin: $space-20 0 0 0;
-  }
-
   & h2 {
     text-align: center;
     font-size: $font-24;

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -165,6 +165,18 @@ main {
   }
 }
 
+/* Shared page-title look for the top <h1> on `/skills`, `/projects`,
+ * `/education`. Previously each route owned its own `__page-title`
+ * BEM element with slightly different rules (margin, font-size, or no
+ * style at all). Hoisting to one class keeps the three index routes
+ * visually consistent without divergent edits. Home (`/`) is excluded
+ * — its `<h1>` is the hero greeting and has its own typography. */
+.route-page-title {
+  margin: $space-20 0 0 0;
+  text-align: center;
+  font-size: $font-30;
+}
+
 /* WCAG 2.4.1 skip-link — visually hidden off-canvas, slides into view
  * on focus so keyboard users can bypass the nav. */
 .root__skip-link {


### PR DESCRIPTION
…cation

The three index routes were rendering their top-of-page titles differently — `/skills` had margin: 20px 0 0 0 and font-size $font-30, `/projects` had margin: 0 and the browser default font-size, and `/education` had no <h1> at all (the two section <h2>s carried the visual weight). Recruiters scanning across the routes got an inconsistent feel.

- New global `.route-page-title` utility in [app/styles/style.css](app/styles/style.css): centered, `$font-30`, `margin: $space-20 0 0 0`. Inlined into the root stylesheet (rides every route via root.tsx's `links()`).
- `/skills` and `/projects` use the global class on their existing <h1>; route-local `__page-title` BEM rules deleted.
- `/education` gains a missing <h1> above the existing two <h2> sections, plus a new `PAGE_TITLE_EDUCATION` intl key (EN: "Education & Certifications", ES: "Educación y certificaciones"). Home is unchanged — its <h1> is the hero greeting and has its own typography.