### PR TITLE
fix(mobile): swap 100vh → 100dvh so iOS Chrome doesn't overflow home

### DIFF
--- a/app/routes/_index/style.css
+++ b/app/routes/_index/style.css
@@ -7,8 +7,12 @@
   justify-content: center;
   /* Fill the visible viewport, minus the bottom-nav height on mobile.
    * --nav-h is 0 at $bp-md (nav is fixed-position there, claims no
-   * vertical space). */
-  min-height: calc(100vh - var(--nav-h));
+   * vertical space). Use `dvh` (dynamic viewport height) so iOS
+   * Chrome's collapsible URL bar doesn't cause the home page to
+   * overflow: `vh` is the *largest* viewport (URL bar hidden), so on
+   * first paint — when the URL bar is still visible — the element
+   * would be taller than the visible area and the page scrolls. */
+  min-height: calc(100dvh - var(--nav-h));
   text-align: center;
   gap: var(--space-32);
   padding: 0 var(--space-20);

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -174,7 +174,10 @@ html {
 
 body {
   display: grid;
-  height: 100vh;
+  /* `dvh` tracks the *visible* viewport so iOS Chrome's collapsible
+   * URL bar doesn't leave a ~120px overflow strip below the fold on
+   * first paint (`vh` is the largest viewport = URL bar hidden). */
+  height: 100dvh;
   margin: 0;
   padding: 0;
   grid-template-rows: 1fr min-content;
@@ -217,7 +220,7 @@ main {
   padding: var(--space-40) var(--space-20);
   margin: 0 auto;
   max-width: 600px;
-  min-height: calc(100vh - var(--nav-h));
+  min-height: calc(100dvh - var(--nav-h));
 
   &__code {
     margin: 0;
@@ -328,7 +331,7 @@ main {
      * under it. */
     display: block;
     height: auto;
-    min-height: 100vh;
+    min-height: 100dvh;
     padding-left: var(--space-200);
   }
 }


### PR DESCRIPTION
Home renders taller than the visible viewport on iOS Chrome — the page becomes scrollable even though the content fits on screen. Not reproducible in Safari DevTools' iPhone emulation.

Root cause: `100vh` is the *largest* viewport height — the size when the URL bar is fully hidden. On iOS Chrome the URL bar is visible on first paint and auto-hides on scroll, so `100vh` resolves to ~120px more than the actually-visible area, and any element sized to it overflows the fold.

Three sites used `100vh` for a full-viewport target:
  - .home-route min-height: subtract --nav-h from viewport
  - body height: root layout grid target
  - .error-boundary min-height: 404/root error state

`dvh` (dynamic viewport height) tracks the *visible* area and updates as the URL bar collapses. Universal support since iOS Safari 15.4 (Mar 2022); Chromium desktop 108+. Desktop behaviour unchanged — `dvh` and `vh` are identical when there's no collapsible UI.