### PR TITLE
ci: add GitHub Actions deploy workflow (replace CF Workers Build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,11 +102,10 @@ jobs:
   lighthouse-pr:
     name: Lighthouse gate
     # Pre-merge Lighthouse against a production-shape preview build
-    # running locally on the runner. Faster than waiting for the
-    # Cloudflare Pages preview deploy URL (no Cloudflare round-trip
-    # to plumb in), and gates the same code path that ships.
-    # Doesn't catch CDN/edge regressions — the post-merge
-    # .github/workflows/lighthouse.yml run against prod still does.
+    # running locally on the runner. Faster than waiting for a Workers
+    # preview URL (no CF round-trip to plumb in), and gates the same
+    # code path that ships. Doesn't catch CDN/edge regressions — the
+    # post-merge .github/workflows/lighthouse.yml run against prod does.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy
+
+# Post-merge deploy to Cloudflare Workers. Runs on every push to `main`
+# and ships `npm run build` + `wrangler deploy`. Replaces the (flaky)
+# Cloudflare Workers Build git-integration path — see PR #245 for the
+# background: CF's build queue silently hung a merge for 24+ hours,
+# leaving prod on the pre-merge bundle without any surface signal.
+#
+# Why GitHub Actions:
+#   - Deploy logs sit next to the other CI checks — visible, retryable,
+#     easy to correlate with a failing merge commit.
+#   - The `npm ci` + `wrangler deploy` chain uses the same commands
+#     `npm run deploy` runs locally, so a "did the deploy succeed?"
+#     answer is one workflow-run inspection away.
+#   - No dependency on CF's opaque build queue.
+#
+# Auth: `CLOUDFLARE_API_TOKEN` (Workers Edit permission, account-scoped)
+# and `CLOUDFLARE_ACCOUNT_ID` live as repo secrets. The token is created
+# in the CF dashboard under My Profile → API Tokens → "Edit Cloudflare
+# Workers" template.
+#
+# Interaction with the Lighthouse workflow: both listen to push-to-main
+# with concurrency groups. Lighthouse's fixed 90s sleep pre-dates this
+# workflow (was working around CF Workers Build's ~30-90s deploy
+# latency); with this deploy job in the same commit hook, that sleep
+# now runs while this workflow does the actual deploy, which is roughly
+# the right timing. If we ever tighten the Lighthouse wait, we can
+# `needs: deploy` from the Lighthouse workflow — for now the loose
+# coupling is fine.
+
+on:
+  push:
+    branches: [main]
+  # Manual trigger for one-off redeploys (e.g. rollback via `git revert`
+  # + push, or if a deploy needs to run without a code change).
+  workflow_dispatch:
+
+# Never let two deploys race. Latest push wins — an older queued deploy
+# for a superseded commit gets cancelled, so prod always ends up on the
+# latest main.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build + deploy to Cloudflare Workers
+    runs-on: ubuntu-latest
+    # Skip the auto-committed Lighthouse post-scoring commits (`[skip ci]`
+    # in the subject). Those don't touch code, so redeploying them would
+    # only bump the version ID in CF without changing what ships.
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Build production bundle
+        run: npm run build
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # `wrangler deploy` reads main + assets + bindings from
+          # wrangler.jsonc. No extra flags needed.
+          command: deploy

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,11 +1,14 @@
 name: Lighthouse
 
-# Runs Lighthouse against production after a push to main lands. Cloudflare
-# Pages auto-deploys merged main commits in ~30-90s, so the workflow waits
-# 90s before measuring to make sure it scores the new code, not the prior
-# version still cached at the edge. (Cloudflare Pages doesn't expose the
-# deployed commit SHA in response headers, so polling-until-match isn't
-# straightforward — a fixed sleep is the pragmatic compromise.)
+# Runs Lighthouse against production after a push to main lands. The
+# sibling `deploy.yml` workflow builds + deploys the same commit; the
+# 90s sleep below gives it time to finish (~60-90s wall-clock in
+# practice: npm ci + build + wrangler upload) before we start scoring
+# the new code. Loose coupling — Lighthouse doesn't `needs: deploy`
+# because a deploy failure shouldn't hide a Lighthouse regression on
+# the currently-serving bundle. If deploy hung, we'd notice via the
+# deploy workflow failing surface, not by Lighthouse silently scoring
+# stale code.
 #
 # Output: a small JSON per route at lighthouse/<route>-<sha>.json with
 # the categories + key metrics + failing audits. The workflow commits

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ The site is content-driven: routes load static JSON files from [public/data/](pu
 
 **Storybook:** Storybook 10 (Vite framework) with stories colocated next to each component as `index.stories.tsx`. See "Storybook" section below.
 
-CI runs lint, typecheck, unit, E2E, and `build-storybook` on every PR ([.github/workflows/ci.yml](.github/workflows/ci.yml)). A separate Lighthouse workflow ([.github/workflows/lighthouse.yml](.github/workflows/lighthouse.yml)) runs on push to `main`, scores the deployed prod URL across five routes, and commits the per-route summaries back to `lighthouse/` with `[skip ci]` — see [lighthouse/README.md](lighthouse/README.md) for the full flow. Dependabot ([.github/dependabot.yml](.github/dependabot.yml)) bumps deps weekly in grouped ecosystems, prefixed `chore(deps)`.
+CI runs lint, typecheck, unit, E2E, and `build-storybook` on every PR ([.github/workflows/ci.yml](.github/workflows/ci.yml)). A deploy workflow ([.github/workflows/deploy.yml](.github/workflows/deploy.yml)) runs on push to `main` and ships `npm run build` + `wrangler deploy` via the `cloudflare/wrangler-action`. A separate Lighthouse workflow ([.github/workflows/lighthouse.yml](.github/workflows/lighthouse.yml)) runs on push to `main`, scores the deployed prod URL across five routes, and commits the per-route summaries back to `lighthouse/` with `[skip ci]` — see [lighthouse/README.md](lighthouse/README.md) for the full flow. Dependabot ([.github/dependabot.yml](.github/dependabot.yml)) bumps deps weekly in grouped ecosystems, prefixed `chore(deps)`.
 
 ---
 
@@ -110,9 +110,9 @@ From [package.json](package.json):
 | ---------------------------- | ---------------------------------------------------------------------------------- |
 | `npm run dev`                | `react-router dev` — local dev server on **port 8788**                             |
 | `npm run build`              | `NODE_ENV=production react-router build` — emits `build/client` and `build/server` |
-| `npm run start`              | `wrangler pages dev ./build/client` — preview the built bundle on Pages            |
-| `npm run preview`            | `npm run build && wrangler pages dev`                                              |
-| `npm run deploy`             | `npm run build && wrangler pages deploy` — deploys to Cloudflare Pages             |
+| `npm run start`              | `wrangler dev` — preview the built bundle locally                                  |
+| `npm run preview`            | `npm run build && wrangler dev`                                                    |
+| `npm run deploy`             | `npm run build && wrangler deploy` — deploys to Cloudflare Workers                 |
 | `npm run typecheck`          | `tsc` (no emit)                                                                    |
 | `npm run typegen`            | `wrangler types` — regenerates `worker-configuration.d.ts` from bindings           |
 | `npm run cf-typegen`         | Alias of the above                                                                 |


### PR DESCRIPTION
Cloudflare Workers Build silently hung PR #244's merge deploy for 24+ hours — the queued job never ran, prod stayed on the pre-merge bundle, and the mobile fix didn't ship until it was deployed manually. No surfaced failure signal, so the only way to notice was the reported user bug still reproducing.

Move deploy into GitHub Actions where the log lives next to the other CI checks. `cloudflare/wrangler-action@v3` runs the same `npm run build` + `wrangler deploy` chain locally-tested via `npm run deploy`, so there's no behavioural drift. Concurrency group cancels superseded deploys; `[skip ci]` commits (Lighthouse post-scoring) are excluded so we don't re-deploy on those.

Also sweeps CF-Pages-era references in CI comments and AGENTS.md's script table (`wrangler pages deploy` → `wrangler deploy`).

Once this merges cleanly, the CF Workers Build git integration should be disconnected from the dashboard to avoid two deploy paths racing.