### PR TITLE
perf(skills): memo lazy sub-components + edge cache + locale cache; a…

### DIFF
--- a/app/components/PendingBoundary/index.tsx
+++ b/app/components/PendingBoundary/index.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { useIntl } from 'react-intl';
+import { useNavigation } from 'react-router';
+
+import { getClassMaker } from '~/utils/utils';
+
+import { renderSkeleton } from './registry';
+
+// Show the skeleton only if the loader hasn't resolved after this many
+// ms. Warm/prefetched navigations (NavBar uses `prefetch="intent"`)
+// resolve in tens of ms and would otherwise flash a skeleton pointlessly.
+// Same tolerance as GitHub's client-side nav shim.
+const SKELETON_DELAY_MS = 150;
+
+const BLOCK = 'pending-boundary';
+const getClasses = getClassMaker(BLOCK);
+
+type Props = {
+  children: React.ReactNode;
+};
+
+// Wraps <Outlet />. When a client-side navigation is in flight and
+// exceeds SKELETON_DELAY_MS, swaps the outgoing route for a route-scoped
+// skeleton picked by the target pathname. Prevents the "outgoing page
+// stays visible" flash on cold nav and gives a stable, layout-preserving
+// placeholder while the loader resolves.
+export default function PendingBoundary({ children }: Props) {
+  const { formatMessage } = useIntl();
+  const navigation = useNavigation();
+
+  // Only treat this as pending if we're actually navigating to a new
+  // location (not just revalidating on a form submission — form actions
+  // go through `state === 'submitting'` first, then 'loading' with a
+  // `formMethod` set; we don't want to swap in a skeleton mid-form).
+  const isPendingNav = navigation.state === 'loading' && navigation.formMethod === undefined;
+  const targetPathname = navigation.location?.pathname;
+
+  const [showSkeleton, setShowSkeleton] = useState(false);
+  useEffect(() => {
+    if (!isPendingNav) return undefined;
+    const id = setTimeout(() => setShowSkeleton(true), SKELETON_DELAY_MS);
+    return () => {
+      clearTimeout(id);
+      setShowSkeleton(false);
+    };
+  }, [isPendingNav]);
+
+  if (showSkeleton && targetPathname) {
+    return (
+      <div
+        className={getClasses()}
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+        aria-label={formatMessage({ id: 'LOADING_ROUTE' })}
+      >
+        {renderSkeleton(targetPathname)}
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/app/components/PendingBoundary/registry.tsx
+++ b/app/components/PendingBoundary/registry.tsx
@@ -1,0 +1,35 @@
+import ContactSkeleton from '~/components/skeletons/ContactSkeleton';
+import EducationDetailSkeleton from '~/components/skeletons/EducationDetailSkeleton';
+import EducationSkeleton from '~/components/skeletons/EducationSkeleton';
+import HomeSkeleton from '~/components/skeletons/HomeSkeleton';
+import ProjectDetailSkeleton from '~/components/skeletons/ProjectDetailSkeleton';
+import ProjectsSkeleton from '~/components/skeletons/ProjectsSkeleton';
+import SkillsDetailSkeleton from '~/components/skeletons/SkillsDetailSkeleton';
+import SkillsSkeleton from '~/components/skeletons/SkillsSkeleton';
+
+// Path → skeleton element. Matched top-down so detail routes ("/skills/1")
+// win over the index ("/skills"). Falls back to the HomeSkeleton for any
+// unknown path — better than showing a spinner or nothing.
+//
+// Returns rendered JSX (not the component reference) so the caller
+// doesn't create a component during render — sidesteps the
+// react-hooks/static-components lint that reasonably objects to
+// dynamic component identity across renders.
+const RULES: Array<{ test: (p: string) => boolean; render: () => React.ReactElement }> = [
+  { test: (p) => p === '/', render: () => <HomeSkeleton /> },
+  { test: (p) => /^\/education\/[^/]+$/.test(p), render: () => <EducationDetailSkeleton /> },
+  { test: (p) => p === '/education', render: () => <EducationSkeleton /> },
+  { test: (p) => /^\/skills\/[^/]+$/.test(p), render: () => <SkillsDetailSkeleton /> },
+  { test: (p) => p === '/skills', render: () => <SkillsSkeleton /> },
+  { test: (p) => /^\/projects\/[^/]+$/.test(p), render: () => <ProjectDetailSkeleton /> },
+  { test: (p) => p === '/projects', render: () => <ProjectsSkeleton /> },
+  { test: (p) => p === '/contact', render: () => <ContactSkeleton /> },
+];
+
+export function renderSkeleton(pathname: string): React.ReactElement {
+  const path = pathname.replace(/\/+$/, '') || '/';
+  for (const rule of RULES) {
+    if (rule.test(path)) return rule.render();
+  }
+  return <HomeSkeleton />;
+}

--- a/app/components/PendingBoundary/style.css
+++ b/app/components/PendingBoundary/style.css
@@ -1,0 +1,19 @@
+/* PendingBoundary is a bare wrapper — layout comes from the route
+ * skeletons themselves. The shimmer + block primitives live in the
+ * shared skeleton stylesheet imported below. */
+@import '../skeletons/style.css';
+
+.pending-boundary {
+  /* Prevent CLS between skeleton and real content: reserve a viewport-
+   * height minimum so the page's total height stays stable during the
+   * swap. Skeletons themselves render at their natural intrinsic sizes. */
+  min-height: 100dvh;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Kill the shimmer sweep for users who opt out; the boxes still
+   * render, they just don't animate. */
+  .skeleton-block::after {
+    animation: none;
+  }
+}

--- a/app/components/TechTree/index.tsx
+++ b/app/components/TechTree/index.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import type { SkillGroup } from '~/utils/utils';
@@ -15,7 +16,9 @@ type Props = {
   groups: SkillGroup[];
 };
 
-export default function TechTree({ groups }: Props) {
+// Memoized so /skills autocomplete keystrokes don't reconcile this
+// tree — `groups` is a stable loader reference.
+function TechTreeImpl({ groups }: Props) {
   return (
     <div className={getClasses()}>
       {groups.map((group) => (
@@ -55,3 +58,6 @@ export default function TechTree({ groups }: Props) {
     </div>
   );
 }
+
+const TechTree = memo(TechTreeImpl);
+export default TechTree;

--- a/app/components/TenureHeatmap/index.tsx
+++ b/app/components/TenureHeatmap/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import type { SkillHeatmapData } from '~/utils/utils';
@@ -38,7 +38,10 @@ type Props = {
   data: SkillHeatmapData;
 };
 
-export default function TenureHeatmap({ data }: Props) {
+// Memoized so the /skills autocomplete keystrokes (which re-render the
+// route, but with a stable `data` reference from the loader) don't
+// reconcile the ~30×9 cell grid on every input event.
+function TenureHeatmapImpl({ data }: Props) {
   const { formatMessage } = useIntl();
   const [showAll, setShowAll] = useState(false);
   // Desktop expands the rendered set to all skills (columns are
@@ -168,3 +171,6 @@ export default function TenureHeatmap({ data }: Props) {
     </div>
   );
 }
+
+const TenureHeatmap = memo(TenureHeatmapImpl);
+export default TenureHeatmap;

--- a/app/components/skeletons/ContactSkeleton.tsx
+++ b/app/components/skeletons/ContactSkeleton.tsx
@@ -1,0 +1,21 @@
+import { SkeletonBlock, SkeletonColumn, SkeletonPage } from './primitives';
+
+// Mirrors app/routes/contact._index — page title + intro paragraph +
+// name/email row + subject + message textarea + submit button.
+export default function ContactSkeleton() {
+  return (
+    <SkeletonPage>
+      <SkeletonBlock variant="title" />
+      <SkeletonBlock variant="text" style={{ width: '75%' }} />
+      <div className="skeleton-row">
+        <SkeletonBlock variant="button" style={{ width: '100%', flex: 1, height: 56 }} />
+        <SkeletonBlock variant="button" style={{ width: '100%', flex: 1, height: 56 }} />
+      </div>
+      <SkeletonColumn>
+        <SkeletonBlock variant="button" style={{ width: '100%', height: 56 }} />
+        <SkeletonBlock variant="button" style={{ width: '100%', height: 180 }} />
+      </SkeletonColumn>
+      <SkeletonBlock variant="button" />
+    </SkeletonPage>
+  );
+}

--- a/app/components/skeletons/EducationDetailSkeleton.tsx
+++ b/app/components/skeletons/EducationDetailSkeleton.tsx
@@ -1,0 +1,18 @@
+import { SkeletonBlock, SkeletonColumn, SkeletonPage } from './primitives';
+
+// Mirrors app/routes/education.$slug — one big degree card.
+export default function EducationDetailSkeleton() {
+  return (
+    <SkeletonPage>
+      <SkeletonBlock variant="title" />
+      <SkeletonBlock variant="subtitle" />
+      <SkeletonColumn>
+        <SkeletonBlock variant="text" />
+        <SkeletonBlock variant="text" style={{ width: '90%' }} />
+        <SkeletonBlock variant="text" style={{ width: '85%' }} />
+        <SkeletonBlock variant="text-short" />
+      </SkeletonColumn>
+      <SkeletonBlock variant="card-tall" />
+    </SkeletonPage>
+  );
+}

--- a/app/components/skeletons/EducationSkeleton.tsx
+++ b/app/components/skeletons/EducationSkeleton.tsx
@@ -1,0 +1,23 @@
+import { SkeletonBlock, SkeletonGrid, SkeletonPage } from './primitives';
+
+// Mirrors app/routes/education._index — page title + degrees grid +
+// certifications grid.
+export default function EducationSkeleton() {
+  return (
+    <SkeletonPage>
+      <SkeletonBlock variant="title" />
+      <SkeletonBlock variant="subtitle" />
+      <SkeletonGrid>
+        <SkeletonBlock variant="card" />
+        <SkeletonBlock variant="card" />
+      </SkeletonGrid>
+      <SkeletonBlock variant="subtitle" />
+      <SkeletonGrid>
+        <SkeletonBlock variant="card" />
+        <SkeletonBlock variant="card" />
+        <SkeletonBlock variant="card" />
+        <SkeletonBlock variant="card" />
+      </SkeletonGrid>
+    </SkeletonPage>
+  );
+}

--- a/app/components/skeletons/HomeSkeleton.tsx
+++ b/app/components/skeletons/HomeSkeleton.tsx
@@ -1,0 +1,24 @@
+import { SkeletonBlock, SkeletonColumn, SkeletonPage, SkeletonRow } from './primitives';
+
+// Mirrors app/routes/_index — hero heading + role/tagline lines + chip
+// row + two CTAs + a small footer link.
+export default function HomeSkeleton() {
+  return (
+    <SkeletonPage>
+      <SkeletonColumn>
+        <SkeletonBlock variant="title" style={{ width: '80%', height: 48 }} />
+        <SkeletonBlock variant="subtitle" style={{ width: '55%' }} />
+        <SkeletonBlock variant="text" style={{ width: '70%' }} />
+      </SkeletonColumn>
+      <SkeletonRow>
+        <SkeletonBlock variant="chip" />
+        <SkeletonBlock variant="chip" style={{ width: 220 }} />
+      </SkeletonRow>
+      <SkeletonRow>
+        <SkeletonBlock variant="button" />
+        <SkeletonBlock variant="button" />
+      </SkeletonRow>
+      <SkeletonBlock variant="text-short" />
+    </SkeletonPage>
+  );
+}

--- a/app/components/skeletons/ProjectDetailSkeleton.tsx
+++ b/app/components/skeletons/ProjectDetailSkeleton.tsx
@@ -1,0 +1,28 @@
+import { SkeletonBlock, SkeletonColumn, SkeletonPage } from './primitives';
+
+// Mirrors app/routes/projects.$slug — big case-study write-up: title +
+// summary + four narrative sections (Problem/Constraints/Approach/
+// Outcome) + tech chips.
+export default function ProjectDetailSkeleton() {
+  return (
+    <SkeletonPage>
+      <SkeletonBlock variant="title" />
+      <SkeletonBlock variant="subtitle" />
+      <SkeletonBlock variant="text" />
+      <SkeletonBlock variant="text" style={{ width: '80%' }} />
+      {['Problem', 'Constraints', 'Approach', 'Outcome'].map((section) => (
+        <SkeletonColumn key={section}>
+          <SkeletonBlock variant="subtitle" style={{ width: '20%' }} />
+          <SkeletonBlock variant="text" />
+          <SkeletonBlock variant="text" style={{ width: '95%' }} />
+          <SkeletonBlock variant="text" style={{ width: '85%' }} />
+        </SkeletonColumn>
+      ))}
+      <div className="skeleton-row">
+        {Array.from({ length: 8 }).map((_, idx) => (
+          <SkeletonBlock key={idx} variant="chip" style={{ width: 90 + ((idx * 17) % 60) }} />
+        ))}
+      </div>
+    </SkeletonPage>
+  );
+}

--- a/app/components/skeletons/ProjectsSkeleton.tsx
+++ b/app/components/skeletons/ProjectsSkeleton.tsx
@@ -1,0 +1,16 @@
+import { SkeletonBlock, SkeletonGrid, SkeletonPage } from './primitives';
+
+// Mirrors app/routes/projects._index — page title + case-study grid.
+export default function ProjectsSkeleton() {
+  return (
+    <SkeletonPage>
+      <SkeletonBlock variant="title" />
+      <SkeletonBlock variant="text" style={{ width: '65%' }} />
+      <SkeletonGrid>
+        <SkeletonBlock variant="card-tall" />
+        <SkeletonBlock variant="card-tall" />
+        <SkeletonBlock variant="card-tall" />
+      </SkeletonGrid>
+    </SkeletonPage>
+  );
+}

--- a/app/components/skeletons/SkillsDetailSkeleton.tsx
+++ b/app/components/skeletons/SkillsDetailSkeleton.tsx
@@ -1,0 +1,27 @@
+import { SkeletonBlock, SkeletonColumn, SkeletonPage } from './primitives';
+
+// Mirrors app/routes/skills.$uuid — logo banner + title + role +
+// description + skills group chips.
+export default function SkillsDetailSkeleton() {
+  return (
+    <SkeletonPage>
+      <SkeletonBlock variant="banner" />
+      <SkeletonColumn>
+        <SkeletonBlock variant="title" style={{ width: '55%' }} />
+        <SkeletonBlock variant="subtitle" style={{ width: '35%' }} />
+        <SkeletonBlock variant="text" />
+        <SkeletonBlock variant="text" style={{ width: '85%' }} />
+        <SkeletonBlock variant="text-short" />
+      </SkeletonColumn>
+      <SkeletonBlock variant="subtitle" style={{ width: '25%' }} />
+      <div className="skeleton-row">
+        <SkeletonBlock variant="chip" />
+        <SkeletonBlock variant="chip" style={{ width: 80 }} />
+        <SkeletonBlock variant="chip" style={{ width: 140 }} />
+        <SkeletonBlock variant="chip" style={{ width: 100 }} />
+        <SkeletonBlock variant="chip" style={{ width: 90 }} />
+        <SkeletonBlock variant="chip" style={{ width: 160 }} />
+      </div>
+    </SkeletonPage>
+  );
+}

--- a/app/components/skeletons/SkillsSkeleton.tsx
+++ b/app/components/skeletons/SkillsSkeleton.tsx
@@ -1,0 +1,29 @@
+import { SkeletonBlock, SkeletonColumn, SkeletonGrid, SkeletonPage } from './primitives';
+
+// Mirrors app/routes/skills._index — page title, autocomplete + timeline
+// cards, "Total years" card, then the SKILLS section (heatmap + TechTree
+// side-by-side on desktop), then EXTRA_ACTIVITIES cards.
+export default function SkillsSkeleton() {
+  return (
+    <SkeletonPage>
+      <SkeletonBlock variant="title" />
+      <SkeletonColumn>
+        <SkeletonBlock variant="button" style={{ width: '100%', maxWidth: 480, height: 48 }} />
+        <SkeletonBlock variant="card" />
+        <SkeletonBlock variant="card" />
+        <SkeletonBlock variant="card" />
+      </SkeletonColumn>
+      <SkeletonBlock variant="subtitle" />
+      <div className="skeleton-grid" style={{ gridTemplateColumns: '2fr 1fr' }}>
+        <SkeletonBlock variant="heatmap" />
+        <SkeletonBlock variant="card-tall" />
+      </div>
+      <SkeletonBlock variant="subtitle" />
+      <SkeletonGrid>
+        <SkeletonBlock variant="card" />
+        <SkeletonBlock variant="card" />
+        <SkeletonBlock variant="card" />
+      </SkeletonGrid>
+    </SkeletonPage>
+  );
+}

--- a/app/components/skeletons/primitives.tsx
+++ b/app/components/skeletons/primitives.tsx
@@ -1,0 +1,39 @@
+// Primitive placeholder blocks composed by every per-route skeleton.
+// Classes live in ./style.css and get inlined via postcss-import from
+// PendingBoundary/style.css → app/styles/style.css.
+
+type BlockProps = {
+  variant?:
+    | 'title'
+    | 'subtitle'
+    | 'text'
+    | 'text-short'
+    | 'chip'
+    | 'button'
+    | 'card'
+    | 'card-tall'
+    | 'banner'
+    | 'heatmap';
+  style?: React.CSSProperties;
+};
+
+export function SkeletonBlock({ variant = undefined, style = undefined }: BlockProps) {
+  const className = variant ? `skeleton-block skeleton-block--${variant}` : 'skeleton-block';
+  return <div className={className} style={style} aria-hidden="true" />;
+}
+
+export function SkeletonPage({ children }: { children: React.ReactNode }) {
+  return <div className="skeleton-page">{children}</div>;
+}
+
+export function SkeletonRow({ children }: { children: React.ReactNode }) {
+  return <div className="skeleton-row">{children}</div>;
+}
+
+export function SkeletonGrid({ children }: { children: React.ReactNode }) {
+  return <div className="skeleton-grid">{children}</div>;
+}
+
+export function SkeletonColumn({ children }: { children: React.ReactNode }) {
+  return <div className="skeleton-column">{children}</div>;
+}

--- a/app/components/skeletons/style.css
+++ b/app/components/skeletons/style.css
@@ -1,0 +1,133 @@
+/* Shared skeleton primitives — every per-route skeleton composes these.
+ * The shimmer is a CSS-only gradient that sweeps across each block via a
+ * ::after pseudo-element. `.skeleton-page` gives every skeleton a
+ * consistent horizontal padding that matches the real routes' outer
+ * wrapper. */
+
+.skeleton-page {
+  padding: var(--space-40) var(--space-24);
+  max-width: var(--layout-max-width, 1200px);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-32);
+}
+
+@media (width <= 767px) {
+  .skeleton-page {
+    padding: var(--space-24) var(--space-16);
+    gap: var(--space-24);
+  }
+}
+
+/* Individual placeholder block. Height + width are set per-instance via
+ * inline style or utility classes below. Border-radius picked to match
+ * the surrounding real UI (chip / button / card corners). */
+.skeleton-block {
+  position: relative;
+  overflow: hidden;
+  background-color: var(--card-bg, rgb(255 255 255 / 0.04));
+  border-radius: 6px;
+  /* min height so a bare block still has visible presence */
+  min-height: 16px;
+}
+
+.skeleton-block::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent 0%, rgb(255 255 255 / 0.06) 50%, transparent 100%);
+  transform: translateX(-100%);
+  animation: skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+[data-theme='light'] .skeleton-block {
+  background-color: rgb(0 0 0 / 0.06);
+}
+
+[data-theme='light'] .skeleton-block::after {
+  background: linear-gradient(90deg, transparent 0%, rgb(0 0 0 / 0.04) 50%, transparent 100%);
+}
+
+@keyframes skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* Modifier classes — semantic sizes used across skeleton shells so they
+ * stay consistent. Route skeletons compose these instead of hand-sizing
+ * every block. */
+.skeleton-block--title {
+  height: 36px;
+  width: 60%;
+  border-radius: 8px;
+}
+
+.skeleton-block--subtitle {
+  height: 22px;
+  width: 40%;
+}
+
+.skeleton-block--text {
+  height: 14px;
+  width: 100%;
+}
+
+.skeleton-block--text-short {
+  height: 14px;
+  width: 60%;
+}
+
+.skeleton-block--chip {
+  height: 28px;
+  width: 120px;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.skeleton-block--button {
+  height: 44px;
+  width: 180px;
+  border-radius: 8px;
+  display: inline-block;
+}
+
+.skeleton-block--card {
+  height: 180px;
+  border-radius: 12px;
+}
+
+.skeleton-block--card-tall {
+  height: 260px;
+  border-radius: 12px;
+}
+
+.skeleton-block--banner {
+  height: 240px;
+  border-radius: 12px;
+}
+
+.skeleton-block--heatmap {
+  height: 320px;
+  border-radius: 12px;
+}
+
+/* Group primitives used by the per-route skeletons */
+.skeleton-row {
+  display: flex;
+  gap: var(--space-12);
+  flex-wrap: wrap;
+}
+
+.skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-16);
+}
+
+.skeleton-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}

--- a/app/intl/en-US.json
+++ b/app/intl/en-US.json
@@ -61,6 +61,7 @@
   "LEARN_MORE": "Learn more",
   "LINKEDIN_PROFILE": "LinkedIn profile",
   "LOADING": "Loading",
+  "LOADING_ROUTE": "Loading page…",
   "LOCALE_TOGGLE_LABEL": "Language",
   "LOCALE_TOGGLE_SWITCH_TO": "Switch to {locale}",
   "NO_MATCHES_FOUND": "No matches found",

--- a/app/intl/es-ES.json
+++ b/app/intl/es-ES.json
@@ -61,6 +61,7 @@
   "LEARN_MORE": "Saber más",
   "LINKEDIN_PROFILE": "Perfil de LinkedIn",
   "LOADING": "Cargando",
+  "LOADING_ROUTE": "Cargando página…",
   "LOCALE_TOGGLE_LABEL": "Idioma",
   "LOCALE_TOGGLE_SWITCH_TO": "Cambiar a {locale}",
   "NO_MATCHES_FOUND": "Sin resultados",

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-router';
 
 import NavBar from '~/components/NavBar';
+import PendingBoundary from '~/components/PendingBoundary';
 import { type Locale, messagesFor, pickLocale } from '~/intl';
 import styles from '~/styles/style.css?url';
 import { getClassMaker } from '~/utils/utils';
@@ -227,7 +228,9 @@ export default function App() {
     <IntlProvider messages={messages} locale={locale} defaultLocale="en">
       <NavBar />
       <main id="main-content">
-        <Outlet />
+        <PendingBoundary>
+          <Outlet />
+        </PendingBoundary>
       </main>
     </IntlProvider>
   );

--- a/app/routes/skills.$uuid/index.tsx
+++ b/app/routes/skills.$uuid/index.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage, useIntl } from 'react-intl';
 import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { isRouteErrorResponse, Link, useLoaderData, useRouteError } from 'react-router';
+import { data, isRouteErrorResponse, Link, useLoaderData, useRouteError } from 'react-router';
 
 import Card from '~/components/Card';
 import { loadSkills } from '~/data/skills-schema';
@@ -92,23 +92,39 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const endLabel = item.endDate ? formatDate(item.endDate, '', undefined, locale) : null;
   const duration = formatDate(item.startDate, item.endDate ?? undefined, 'fullYearMonth', locale);
 
-  return {
-    data: {
-      id: item.id,
-      title: item.title,
-      startDate: item.startDate,
-      endDate: item.endDate,
-      rol: localized(item, 'rol', locale),
-      description: localized(item, 'description', locale),
-      projects,
-      skillGroups: getSkillGroupsForJob(SKILLS, item.id, locale),
-      startLabel,
-      endLabel,
-      duration,
+  return data(
+    {
+      data: {
+        id: item.id,
+        title: item.title,
+        startDate: item.startDate,
+        endDate: item.endDate,
+        rol: localized(item, 'rol', locale),
+        description: localized(item, 'description', locale),
+        projects,
+        skillGroups: getSkillGroupsForJob(SKILLS, item.id, locale),
+        startLabel,
+        endLabel,
+        duration,
+      },
+      imagePath,
+      imageDims,
     },
-    imagePath,
-    imageDims,
-  };
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=3600',
+        // Same reasoning as /skills — payload varies by locale, and
+        // `pickLocale` reads both `?lang=` and the `locale` cookie.
+        Vary: 'Accept-Language, Cookie',
+      },
+    }
+  );
+}
+
+// Explicit `headers` export required to propagate the loader's response
+// headers under RR v8's Single Fetch aggregation.
+export function headers({ loaderHeaders }: { loaderHeaders: Headers }) {
+  return loaderHeaders;
 }
 
 export function ErrorBoundary() {

--- a/app/routes/skills._index/index.tsx
+++ b/app/routes/skills._index/index.tsx
@@ -7,7 +7,7 @@ import Card from '~/components/Card';
 import Input from '~/components/Input';
 import LoadingSpinner from '~/components/LoadingSpinner';
 import { loadSkills } from '~/data/skills-schema';
-import { pickLocale } from '~/intl';
+import { type Locale, pickLocale } from '~/intl';
 import { mergeRouteMeta } from '~/utils/meta';
 import {
   formatDate,
@@ -65,30 +65,65 @@ const SKILLS = loadSkills(skillsJson);
 const SUGGESTIONS = getSkillSuggestions(SKILLS);
 const WORK_ITEMS_REVERSED = [...SKILLS.WORK_ITEMS].reverse();
 
+// Per-locale derivations are pure functions over the deploy-time-frozen
+// `SKILLS` payload, so memoize them at module scope. The Map is keyed by
+// Locale (currently `'en' | 'es'`) and populated lazily on first request
+// per worker. Each entry sticks until the next deploy replaces the
+// worker. Safe: the JSON is baked into the server bundle, so nothing
+// under `SKILLS` mutates at runtime.
+type LocalizedSkillsBundle = {
+  timelineCards: Array<{
+    id: string;
+    title: string;
+    date: string;
+    texts: string[];
+    textsLabel: string;
+    skills: string[];
+  }>;
+  techTreeGroups: ReturnType<typeof getAllSkillGroups>;
+  extraActivities: Array<{
+    title: string;
+    data: Array<{ title: string; text: string }>;
+  }>;
+};
+
+const LOCALIZED_CACHE = new Map<Locale, LocalizedSkillsBundle>();
+
+function getLocalizedBundle(locale: Locale): LocalizedSkillsBundle {
+  const cached = LOCALIZED_CACHE.get(locale);
+  if (cached) return cached;
+  const bundle: LocalizedSkillsBundle = {
+    timelineCards: WORK_ITEMS_REVERSED.map((item) => ({
+      id: String(item.id),
+      title: item.title,
+      date: formatDate(item.startDate, item.endDate ?? undefined),
+      texts: [localized(item, 'rol', locale)],
+      textsLabel: 'ROLE',
+      skills: getSkillGroupsForJob(SKILLS, item.id, locale).flatMap((g) => g.items),
+    })),
+    techTreeGroups: getAllSkillGroups(SKILLS, locale),
+    extraActivities: SKILLS.EXTRA_ACTIVITIES.map((activity) => ({
+      title: activity.title,
+      data: activity.data.map((d) => ({
+        title: localized(d, 'title', locale),
+        text: localized(d, 'text', locale),
+      })),
+    })),
+  };
+  LOCALIZED_CACHE.set(locale, bundle);
+  return bundle;
+}
+
 export async function loader({ request }: LoaderFunctionArgs) {
   const locale = pickLocale(request);
-  const timelineCards = WORK_ITEMS_REVERSED.map((item) => ({
-    id: String(item.id),
-    title: item.title,
-    date: formatDate(item.startDate, item.endDate ?? undefined),
-    texts: [localized(item, 'rol', locale)],
-    textsLabel: 'ROLE',
-    skills: getSkillGroupsForJob(SKILLS, item.id, locale).flatMap((g) => g.items),
-  }));
-  const extraActivities = SKILLS.EXTRA_ACTIVITIES.map((activity) => ({
-    title: activity.title,
-    data: activity.data.map((d) => ({
-      title: localized(d, 'title', locale),
-      text: localized(d, 'text', locale),
-    })),
-  }));
+  const { timelineCards, techTreeGroups, extraActivities } = getLocalizedBundle(locale);
   return remixData(
     {
       data: timelineCards,
       yearsOfExp: formatDate(SKILLS.WORK_ITEMS[0].startDate, undefined, 'fullYearMonth'),
       skills: SUGGESTIONS,
       heatmapData: getSkillHeatmapData(SKILLS),
-      techTreeGroups: getAllSkillGroups(SKILLS, locale),
+      techTreeGroups,
       extraActivities,
     },
     {

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -1,6 +1,7 @@
 /* stylelint-disable font-family-name-quotes */
 
 @import '../components/NavBar/style.css';
+@import '../components/PendingBoundary/style.css';
 
 /* ─── Theme system ────────────────────────────────────────────────
  *

--- a/app/utils/utils.tsx
+++ b/app/utils/utils.tsx
@@ -199,8 +199,20 @@ function resolveRange(
   return clippedEnd > clippedStart ? { start: clippedStart, end: clippedEnd } : null;
 }
 
+// Cache keyed by the SkillsData reference + `${year}-${month}` so a
+// worker instance that serves multiple cold-start /skills requests
+// within the same calendar month only builds the heatmap once. Output
+// depends on `new Date()` (for the year span's "ongoing job" clamp and
+// current-month bucket), so invalidate when the month rolls over. Also
+// keyed by reference so unit tests with different fixtures each get a
+// fresh compute — production always passes the deploy-frozen singleton.
+const HEATMAP_CACHE = new WeakMap<SkillsData, { key: string; value: SkillHeatmapData }>();
+
 export function getSkillHeatmapData(skillsData: SkillsData): SkillHeatmapData {
   const now = new Date();
+  const cacheKey = `${now.getFullYear()}-${now.getMonth()}`;
+  const cached = HEATMAP_CACHE.get(skillsData);
+  if (cached && cached.key === cacheKey) return cached.value;
   const nowMs = now.getTime();
   const currentYear = now.getFullYear();
 
@@ -291,7 +303,9 @@ export function getSkillHeatmapData(skillsData: SkillsData): SkillHeatmapData {
     if (aLast !== bLast) return bLast - aLast;
     return b.total - a.total;
   });
-  return { years, rows };
+  const value: SkillHeatmapData = { years, rows };
+  HEATMAP_CACHE.set(skillsData, { key: cacheKey, value });
+  return value;
 }
 
 // Skills attached to a single job, bucketed by category. The `id` on

--- a/tests/e2e/pending-boundary.spec.ts
+++ b/tests/e2e/pending-boundary.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+
+// Verifies the PendingBoundary skeleton shows during a slow client-side
+// navigation. RR v8 fires an internal single-fetch request on client
+// nav (`_data` query on the destination path); we delay just that so
+// the outgoing route stays visible past SKELETON_DELAY_MS and the
+// skeleton renders.
+test.describe('PendingBoundary skeleton', () => {
+  test('renders route-scoped skeleton on slow client navigation', async ({ page }) => {
+    await page.goto('/');
+
+    // Slow every request to /skills (both the RR single-fetch `.data`
+    // request and any route-lazy chunk fetch) so the SPA transition
+    // sits in the 'loading' state past the 150ms show-threshold.
+    await page.route(/\/skills(\.data)?(\?|$)/, async (route) => {
+      await new Promise((r) => {
+        setTimeout(r, 1200);
+      });
+      await route.continue();
+    });
+
+    // Trigger client-side nav via the NavBar Skills link (labelled "CV"
+    // in the nav — see MAIN_NAV in app/components/NavBar/index.tsx).
+    await page.getByRole('link', { name: /CV/i }).first().click();
+
+    // Skeleton exists briefly and is announced to assistive tech.
+    // Use `waitFor` with a short window because the skeleton starts
+    // hidden (150ms delay) and disappears once the throttled loader
+    // resolves.
+    const skeleton = page.getByRole('status', { name: /loading page/i });
+    await expect(skeleton).toBeVisible({ timeout: 2000 });
+    // Skeleton has the aria-busy attribute so screen readers announce
+    // "loading" not "loaded" during the transition.
+    await expect(skeleton).toHaveAttribute('aria-busy', 'true');
+
+    // Once the loader resolves, the skeleton is gone and the real page
+    // renders.
+    await expect(page.getByRole('heading', { name: /Skills & Work Experience/i })).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(skeleton).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
…dd PendingBoundary skeletons

Perf sweep on /skills + friends:

- `TenureHeatmap` and `TechTree` are now `React.memo`. Their `data`/ `groups` props are stable loader references, so the autocomplete keystroke-driven re-render of the parent no longer reconciles the ~30×9 cell heatmap grid or the tech-tree list on every input event.
- `/skills/:uuid` picks up the same 1h edge cache + `Vary: Accept-Language, Cookie` that `/skills` already had, via the paired `data(...)` + `headers` export.
- `/skills` loader memoizes per-locale derivations (`timelineCards`, `techTreeGroups`, `extraActivities`) in a module-scope `Map<Locale, …>`. The JSON is deploy-frozen, so the cache holds for the life of the worker instance and shaves the derivation cost off every cold-start request within a warm worker.
- `getSkillHeatmapData` gains a `WeakMap<SkillsData, {key, value}>` keyed by `${year}-${month}` — same cold-start argument. WeakMap keying by the input reference keeps unit tests independent (each fixture is a fresh object, so no cache leakage between tests).

Loading skeletons for client-side navigation:

- New `PendingBoundary` wraps `<Outlet />` in `app/root.tsx`. Reads `useNavigation()` and, after a 150ms grace period (so warm/prefetched nav via NavBar's `prefetch="intent"` never flashes a skeleton), swaps in a route-scoped placeholder. Ignores form submissions so `/contact` action posts don't trigger it.
- One skeleton per route (Home/Skills/Education/Projects/Contact + the three detail routes) composed from a small set of shared primitives (`SkeletonBlock`, `SkeletonPage`, `SkeletonRow`, `SkeletonGrid`, `SkeletonColumn`). Registry in `PendingBoundary/registry.tsx` matches pathnames top-down so detail routes win over their index.
- Shimmer animation via CSS ::after gradient; suppressed under `prefers-reduced-motion`. Skeleton styles ride the global stylesheet via postcss-import so no per-route CSS split needed.
- E2E spec in `tests/e2e/pending-boundary.spec.ts` throttles the RR single-fetch `.data` request for `/skills` and asserts the `role="status"` skeleton renders with `aria-busy="true"`.
- `LOADING_ROUTE` intl key added to `en-US.json` + `es-ES.json` for the boundary's aria-label.

Non-changes: skipped a `prop-types` minified alias (P6) — the `prop-types` npm package doesn't ship a `.min.js` entry, so the alias target was fictional.