### PR TITLE
fix(i18n): localize 'Present', thread locale through /skills, fix og:…

### DIFF
--- a/app/intl/index.ts
+++ b/app/intl/index.ts
@@ -20,7 +20,13 @@ function readCookie(request: Request, name: string): string | null {
     const eq = part.indexOf('=');
     if (eq === -1) continue;
     if (part.slice(0, eq).trim() === name) {
-      return decodeURIComponent(part.slice(eq + 1).trim());
+      // Malformed %-escapes throw URIError; treat as an absent cookie
+      // rather than 500-ing the whole SSR pass.
+      try {
+        return decodeURIComponent(part.slice(eq + 1).trim());
+      } catch {
+        return null;
+      }
     }
   }
   return null;

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -67,10 +67,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
   };
 }
 
-export const meta: MetaFunction = () => {
+const OG_LOCALES: Record<Locale, string> = { en: 'en_US', es: 'es_ES' };
+
+export const meta: MetaFunction<typeof loader> = ({ loaderData }) => {
   const title = 'Gonzalo Alvarez Campos — Senior Software Engineer';
   const description =
     'Full-stack engineer with 7+ years building React, TypeScript, Remix, and Next.js apps in fintech and education.';
+  const ogLocale = OG_LOCALES[loaderData?.locale ?? 'en'];
   return [
     { title },
     { name: 'description', content: description },
@@ -85,7 +88,7 @@ export const meta: MetaFunction = () => {
     { property: 'og:description', content: description },
     { property: 'og:url', content: SITE_URL },
     { property: 'og:site_name', content: 'Gonzalo Alvarez Campos' },
-    { property: 'og:locale', content: 'en_US' },
+    { property: 'og:locale', content: ogLocale },
     { property: 'og:image', content: OG_IMAGE_URL },
     { property: 'og:image:secure_url', content: OG_IMAGE_URL },
     { property: 'og:image:type', content: 'image/png' },

--- a/app/routes/skills._index/index.tsx
+++ b/app/routes/skills._index/index.tsx
@@ -97,7 +97,7 @@ function getLocalizedBundle(locale: Locale): LocalizedSkillsBundle {
     timelineCards: WORK_ITEMS_REVERSED.map((item) => ({
       id: String(item.id),
       title: item.title,
-      date: formatDate(item.startDate, item.endDate ?? undefined),
+      date: formatDate(item.startDate, item.endDate ?? undefined, undefined, locale),
       texts: [localized(item, 'rol', locale)],
       textsLabel: 'ROLE',
       skills: getSkillGroupsForJob(SKILLS, item.id, locale).flatMap((g) => g.items),
@@ -121,7 +121,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return data(
     {
       data: timelineCards,
-      yearsOfExp: formatDate(SKILLS.WORK_ITEMS[0].startDate, undefined, 'fullYearMonth'),
+      yearsOfExp: formatDate(SKILLS.WORK_ITEMS[0].startDate, undefined, 'fullYearMonth', locale),
       skills: SUGGESTIONS,
       heatmapData: getSkillHeatmapData(SKILLS),
       techTreeGroups,

--- a/app/utils/utils.test.tsx
+++ b/app/utils/utils.test.tsx
@@ -98,6 +98,10 @@ describe('formatDate', () => {
     expect(out).toMatch(/años|meses/);
     expect(out).not.toMatch(/years|months/);
   });
+
+  it('renders "Presente" when locale=es and end is undefined', () => {
+    expect(formatDate('2020-01', undefined, undefined, 'es')).toBe('01/2020 - Presente');
+  });
 });
 
 describe('getSkillHeatmapData', () => {

--- a/app/utils/utils.tsx
+++ b/app/utils/utils.tsx
@@ -64,9 +64,8 @@ export const getClassMaker =
 // shifts to the prior day in negative-offset timezones.
 const parseYearMonth = (s: string): Date => new Date(`${s}-01T00:00:00`);
 
-// `locale` only affects the human-readable formats — `fullYearMonth`
-// ("4 años 2 meses") and the single-month case ("agosto 2018"). The
-// numeric `MM/yyyy` branches are locale-neutral.
+const PRESENT_LITERAL: Record<Locale, string> = { en: 'Present', es: 'Presente' };
+
 export const formatDate = (
   dateA: string,
   dateB?: string,
@@ -83,7 +82,7 @@ export const formatDate = (
   }
 
   if (dateB === null || dateB === undefined) {
-    return `${format(parseYearMonth(dateA), 'MM/yyyy')} - Present`;
+    return `${format(parseYearMonth(dateA), 'MM/yyyy')} - ${PRESENT_LITERAL[locale]}`;
   }
 
   if (dateB === '') {


### PR DESCRIPTION
…locale, harden cookie decode

Five Spanish-locale bugs surfaced by the last sweep:

- formatDate hard-coded ' - Present' regardless of locale — the Qubika timeline card rendered 'Presente' in Spanish now.
- /skills loader's yearsOfExp call omitted the locale arg, so the duration string was 'years/months' for Spanish visitors.
- Same loader's getLocalizedBundle timeline `date` call also dropped locale (masked for closed jobs by the numeric MM/yyyy format, but wrong once combined with the Present fix).
- app/root.tsx meta() hard-coded og:locale=en_US; now reads MetaFunction<typeof loader>.loaderData.locale and maps to en_US / es_ES so LinkedIn/Slack embeds reflect the actual locale.
- readCookie's decodeURIComponent threw URIError on malformed values (e.g. `locale=%FF`), 500-ing the SSR pass. Now falls through to the next locale signal on decode failure.

Added a unit test for the new Presente branch.