### PR TITLE
fix: URL-lang priority, cache stripping, honeypot hardening, misc

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -73,7 +73,7 @@ export const meta: MetaFunction<typeof loader> = ({ loaderData }) => {
   return [
     { title },
     { name: 'description', content: description },
-    { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+    { name: 'viewport', content: 'width=device-width,initial-scale=1,minimum-scale=1' },
     // Match the actual app background so mobile browser chrome doesn't
     // flash white on the dark theme.
     { name: 'theme-color', content: '#010408' },
@@ -131,22 +131,11 @@ const PERSON_JSONLD = {
 // [data-theme='light'] selector swaps the palette tokens.
 const THEME_INIT_SCRIPT = `try{var t=localStorage.getItem('theme');if(t==='light'||t==='dark')document.documentElement.dataset.theme=t;else if(matchMedia('(prefers-color-scheme: light)').matches)document.documentElement.dataset.theme='light';}catch(e){}`;
 
-// Inline locale-replay script. Runs synchronously in <head>; covers
-// the pre-cookie migration case where a user previously chose a locale
-// (persisted in localStorage.locale by older builds) but the cookie
-// channel hasn't been seeded yet. If localStorage holds a locale that
-// differs from what the loader resolved, write the cookie and redirect
-// to ?lang=<saved> so the next render picks it up. Once the cookie
-// lands, every subsequent request — including internal <Link> nav —
-// resolves the right locale server-side and this branch becomes a
-// no-op (the loader already matches localStorage).
-//
-// Reads the loader-resolved locale off `document.documentElement.lang`
-// (the `<html lang>` attribute) instead of interpolating it into the
-// script body — keeps the script a static string so its CSP script
-// hash stays stable across locales. `?lang=` is the highest-priority
-// signal in pickLocale so the redirect always wins on first paint.
-const LOCALE_REPLAY_SCRIPT = `try{var s=localStorage.getItem('locale');if((s==='en'||s==='es')&&s!==document.documentElement.lang){document.cookie='locale='+s+';Path=/;Max-Age=31536000;SameSite=Lax';var u=new URL(location.href);if(u.searchParams.get('lang')!==s){u.searchParams.set('lang',s);location.replace(u.toString());}}}catch(e){}`;
+// Replay a saved localStorage locale for pre-cookie visitors. Reads
+// the loader locale off `<html lang>` so the script body stays static
+// across locales. Bails when the URL already has `?lang=` so explicit
+// share/deep-links win over stored preferences.
+const LOCALE_REPLAY_SCRIPT = `try{if(new URL(location.href).searchParams.has('lang'))throw 0;var s=localStorage.getItem('locale');if((s==='en'||s==='es')&&s!==document.documentElement.lang){document.cookie='locale='+s+';Path=/;Max-Age=31536000;SameSite=Lax';var u=new URL(location.href);u.searchParams.set('lang',s);location.replace(u.toString());}}catch(e){}`;
 
 // WebSite schema gives Google enough to surface a sitelinks search box
 // in SERPs and helps disambiguate the property when crawled. Kept
@@ -160,6 +149,16 @@ const WEBSITE_JSONLD = {
   inLanguage: ['en', 'es'],
   author: { '@type': 'Person', name: 'Gonzalo Alvarez Campos' },
 };
+
+// Escape the two characters that can break out of an inline
+// <script type="application/ld+json"> — `</` closes the tag early,
+// U+2028/U+2029 break JS parsers pre-ES2019 rendered payloads.
+function jsonLd(obj: unknown): string {
+  return JSON.stringify(obj)
+    .replace(/</g, '\\u003c')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
 
 type LayoutData = {
   locale: Locale;
@@ -198,7 +197,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
     <html lang={locale} suppressHydrationWarning>
       <head>
         <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1" />
         {/* Theme init runs before paint; keep it before any <link>
             tags that pull stylesheets. */}
         <script nonce={cspNonce} dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
@@ -212,12 +210,12 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <script
           type="application/ld+json"
           nonce={cspNonce}
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(PERSON_JSONLD) }}
+          dangerouslySetInnerHTML={{ __html: jsonLd(PERSON_JSONLD) }}
         />
         <script
           type="application/ld+json"
           nonce={cspNonce}
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(WEBSITE_JSONLD) }}
+          dangerouslySetInnerHTML={{ __html: jsonLd(WEBSITE_JSONLD) }}
         />
       </head>
       <body className={getClasses()}>

--- a/app/routes/contact._index/index.tsx
+++ b/app/routes/contact._index/index.tsx
@@ -76,10 +76,27 @@ export async function action({ request, context }: ActionFunctionArgs) {
   const formData = await request.formData();
   const raw = Object.fromEntries(formData);
 
-  // Validate first so a malformed payload can't poison the rate
-  // limit. Silent-drop honeypot failures before validation reports
-  // them — a bot getting "website too long" back is a signal.
-  if (typeof raw.website === 'string' && raw.website.length > 0) {
+  // Rate limit by client IP. CF-Connecting-IP is set by Cloudflare's
+  // edge and is the canonical visitor IP regardless of any
+  // X-Forwarded-For chain. Fall back to a sentinel so the rule still
+  // fires under local dev. Runs BEFORE honeypot / validation so both
+  // the silent-drop and the real send path pay the same KV round-trip
+  // — otherwise a bot could distinguish honeypot-drop from a real send
+  // by response latency.
+  const ip = request.headers.get('CF-Connecting-IP') ?? 'local-dev';
+  const key = `ratelimit:contact:${await hashIp(ip)}`;
+  const current = await env.RATELIMIT_KV.get(key);
+  const count = current ? Number.parseInt(current, 10) || 0 : 0;
+  if (count >= RATE_LIMIT_PER_HOUR) {
+    return data<ActionResponse>({ status: 'error', reason: 'rate-limit' }, { status: 429 });
+  }
+
+  // Silent-drop honeypot. Any non-empty value, or any non-string entry
+  // (bots have posted `File` payloads to leak the field name via Zod's
+  // `invalid_type` error map), returns 200 as if the message went out.
+  const hp = raw.website;
+  if (hp !== undefined && (typeof hp !== 'string' || hp.length > 0)) {
+    await env.RATELIMIT_KV.put(key, String(count + 1), { expirationTtl: 3600 });
     return data<ActionResponse>({ status: 'ok' });
   }
 
@@ -88,7 +105,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
     const fieldErrors: FieldErrors = {};
     for (const issue of parsed.error.issues) {
       const path = issue.path[0];
-      if (typeof path === 'string') {
+      if (typeof path === 'string' && path !== 'website') {
         fieldErrors[path as keyof FieldErrors] = mapIssueToIntlKey(path, issue.code);
       }
     }
@@ -98,17 +115,6 @@ export async function action({ request, context }: ActionFunctionArgs) {
     );
   }
 
-  // Rate limit by client IP. CF-Connecting-IP is set by Cloudflare's
-  // edge and is the canonical visitor IP regardless of any
-  // X-Forwarded-For chain. Fall back to a sentinel so the rule still
-  // fires under local dev (where the header is unset).
-  const ip = request.headers.get('CF-Connecting-IP') ?? 'local-dev';
-  const key = `ratelimit:contact:${await hashIp(ip)}`;
-  const current = await env.RATELIMIT_KV.get(key);
-  const count = current ? Number.parseInt(current, 10) || 0 : 0;
-  if (count >= RATE_LIMIT_PER_HOUR) {
-    return data<ActionResponse>({ status: 'error', reason: 'rate-limit' }, { status: 429 });
-  }
   await env.RATELIMIT_KV.put(key, String(count + 1), { expirationTtl: 3600 });
 
   // Send via Resend. Bare fetch — no SDK dependency, no Node-isms to

--- a/app/utils/load-context.ts
+++ b/app/utils/load-context.ts
@@ -48,15 +48,19 @@ const DEV_STUB_CLOUDFLARE: Cloudflare = {
 
 export function getCloudflare(context: Readonly<RouterContextProvider>): Cloudflare {
   const cloudflare = (context as AppLoadContext).cloudflare;
-  if (!cloudflare) {
-    // Vite's SSR dev runtime (`npm run dev`) doesn't go through
-    // `workers/app.ts`, so `cloudflare` is undefined there. Return
-    // the stub above so route actions like `/contact` still exercise
-    // their happy path in dev. Prod always populates this via the
-    // Worker before invoking the handler.
-    return DEV_STUB_CLOUDFLARE;
+  if (cloudflare) return cloudflare;
+  // Vite's SSR dev runtime skips `workers/app.ts`, so `cloudflare` is
+  // undefined and we hand out a stub so `/contact` runs end-to-end
+  // locally. In prod the Worker always populates the context — a
+  // regression that skips it would silently `RESEND_API_KEY: 'dev-stub-key'`
+  // its way to a 401 loop. Throw loudly instead.
+  if (import.meta.env.PROD) {
+    throw new Error(
+      'load-context: cloudflare bindings missing on the request context. ' +
+        'This should never happen in prod; check workers/app.ts for a broken wrapping.'
+    );
   }
-  return cloudflare;
+  return DEV_STUB_CLOUDFLARE;
 }
 
 // Per-request CSP nonce. Falls back to '' when the context wasn't

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -75,18 +75,20 @@ const STATIC_SECURITY_HEADERS: Record<string, string> = {
     'camera=(), microphone=(), geolocation=(), interest-cohort=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()',
 };
 
-// SSR HTML embeds the per-request nonce on every inline <script>.
-// Route loaders set `Cache-Control: public, ...` for edge caching of
-// the JSON `.data` payload (nonce-free) — but the same header rides
-// the HTML response, and a shared cache would then serve one visitor's
-// nonce to every visitor for up to `max-age`. Force `private` on the
-// HTML path so the browser can still cache but no shared cache holds
-// the nonce.
+// See docs/security.md § "SSR HTML is Cache-Control: private". Also
+// strip `s-maxage` / `proxy-revalidate` — those directives are for
+// shared caches and would let a non-conforming intermediary hold the
+// nonced HTML despite `private`.
 function privatizeCacheControl(headers: Headers): void {
   const cc = headers.get('Cache-Control');
-  if (cc && /\bpublic\b/i.test(cc)) {
-    headers.set('Cache-Control', cc.replace(/\bpublic\b/gi, 'private'));
-  }
+  if (!cc) return;
+  const scrubbed = cc
+    .split(',')
+    .map((d) => d.trim())
+    .filter((d) => !/^(s-maxage|proxy-revalidate)\b/i.test(d))
+    .map((d) => (/^public\b/i.test(d) ? 'private' : d))
+    .join(', ');
+  if (scrubbed !== cc) headers.set('Cache-Control', scrubbed);
 }
 
 function withSecurityHeaders(


### PR DESCRIPTION
Seven small correctness / hardening fixes surfaced by the last sweep.

- LOCALE_REPLAY_SCRIPT now bails when the current URL already carries `?lang=` — a shared /education?lang=en link no longer gets redirected back to the visitor's localStorage locale on paint.
- privatizeCacheControl also strips `s-maxage` and `proxy-revalidate` from nonced HTML responses. `Cache-Control: private, ..., s-maxage=…` is contradictory (RFC 7234); non-conforming intermediaries that read s-maxage while ignoring `private` would hold the per-request nonce.
- Contact honeypot silent-drops on any non-string / non-empty value (bots were posting `website` as a `File` to leak the field name via Zod's error map). The rate-limit KV read also runs BEFORE the honeypot check so silent-drop and real-send pay the same round-trip — closes the timing distinguisher.
- Contact validation errors filter out `website` before returning the fieldErrors map (belt + suspenders — the honeypot check already runs first, but any future reorder can't leak).
- app/root.tsx head no longer emits a hardcoded <meta name="viewport"> in addition to the one produced by the `meta` export — the two had different `initial-scale` / `minimum-scale` directives. Kept the stricter (`initial-scale=1,minimum-scale=1`) via the meta export.
- JSON-LD payloads now go through a small `jsonLd()` helper that escapes `<` → `<` and U+2028/U+2029. Hardcoded today, landmine for the next content edit.
- getCloudflare throws in production when the context arrives without cloudflare bindings — was silently falling back to `dev-stub-key`, which would 401 against Resend and log "send failed" without any louder signal. Only dev still returns the stub.